### PR TITLE
Add ros_control to the simulation

### DIFF
--- a/carpincho_bringup/launch/teleop.launch
+++ b/carpincho_bringup/launch/teleop.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <node name="teleop" pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" ns="carpincho" output="screen">
+    <param name="speed" value="0.3"/>
+    <param name="turn" value="1.4"/>
+    <remap from="cmd_vel" to="mobile_base_controller/cmd_vel" />
+  </node>
+
+</launch>

--- a/carpincho_description/config/carpincho/base.yaml
+++ b/carpincho_description/config/carpincho/base.yaml
@@ -1,5 +1,6 @@
 base:
-  mass: 0.8               # Base mass in Kg
+  #mass: 0.8               # Base mass in Kg
+  mass: 6.0               # We use a bigger mass to be able to run with Gazebo ROS Control.
   x_size: 0.195           # Dimension in x axis
   y_size: 0.08            # Dimension in y axis
   z_size: 0.005           # Dimension in z axis

--- a/carpincho_description/config/carpincho/front_wheel.yaml
+++ b/carpincho_description/config/carpincho/front_wheel.yaml
@@ -1,4 +1,4 @@
-mass: 0.5        # Wheel mass in Kg
+mass: 0.032        # Wheel mass in Kg
 radius: 0.0331    # Wheel radius in m
 length: 0.025     # Wheel length in m, considering is as a cylinder
 mesh: '../components/wheel.stl'          # Name of the mesh files. Leave it empty ('') to have a red wheel

--- a/carpincho_description/urdf/include/common_macros.urdf.xacro
+++ b/carpincho_description/urdf/include/common_macros.urdf.xacro
@@ -68,6 +68,7 @@
       <parent link="base_link"/>
       <child link="${prefix}_wheel"/>
       <origin xyz="${pos_x_joint} ${reflect* pos_y_joint} ${pos_z_joint}" rpy="0 0 0"/>
+      <dynamics damping="0.0" friction="4.5"/>
     </joint>
 
     <transmission name="${prefix}_wheel_transmission">

--- a/carpincho_simulation/config/carpincho_control_sim.yaml
+++ b/carpincho_simulation/config/carpincho_control_sim.yaml
@@ -1,0 +1,10 @@
+# PID Gains for Gazebo ROS control
+carpincho:
+  gazebo_ros_control:
+    pid_gains:
+      front_right_wheel_joint:
+        p: 2.0
+        i: 4.0
+      front_left_wheel_joint:
+        p: 2.0
+        i: 4.0

--- a/carpincho_simulation/launch/bringup.launch
+++ b/carpincho_simulation/launch/bringup.launch
@@ -4,13 +4,13 @@
   <arg name="paused" default="false" doc="True to start the simulation on a PAUSED state" />
   <arg name="gui" default="true"  doc="True to launch the Gazebo GUI" />
   <arg name="debug" default="false" doc="True to: execute Gazebo with gdb." />
+  <arg name="model_name" default="carpincho" doc="Name for the Gazebo model instance" />
 
+ <!-- Starting Pose Options  -->
   <arg name="initial_pose_x" default="0.0" doc="Initial pose of the carpincho on the x axis" />
   <arg name="initial_pose_y" default="0.0" doc="Initial pose of the carpincho on the y axis" />
   <arg name="initial_pose_z" default="0.0" doc="Initial pose of the carpincho on the x axis" />
   <arg name="initial_pose_yaw" default="0.0" doc="Initial yaw orientation of the mover" />
-
-  <arg name="model_name" default="carpincho" doc="Name for the Gazebo model instance" />
 
   <param name="robot_description"
       command="$(find xacro)/xacro '$(find carpincho_simulation)/urdf/carpincho.gazebo.xacro' " />
@@ -23,11 +23,19 @@
 
     <node name="carpincho_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
         args="-urdf -param /robot_description -model $(arg model_name)
-              -x $(arg initial_pose_x) -y $(arg initial_pose_y) -z $(arg initial_pose_z) -R 0 -P 0 -Y $(arg initial_pose_yaw)" /> 
+              -x $(arg initial_pose_x) -y $(arg initial_pose_y) -z $(arg initial_pose_z)
+              -R 0 -P 0 -Y $(arg initial_pose_yaw) -robot_namespace $(arg model_name)" /> 
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" >
       <param name="use_tf_static" value="true"/>
       <param name="robot_description" value="robot_description"/>    
     </node>
+
+  <rosparam file="$(find carpincho_control)/config/carpincho_control.yaml" command="load" />
+
+  <rosparam file="$(find carpincho_simulation)/config/carpincho_control_sim.yaml" command="load" />
+
+  <node name="control_spawner" pkg="controller_manager" type="spawner"
+        ns="carpincho" args="mobile_base_controller joint_state_controller" output="screen"/>
 
 </launch>

--- a/carpincho_simulation/package.xml
+++ b/carpincho_simulation/package.xml
@@ -50,7 +50,10 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
 
   <buildtool_depend>catkin</buildtool_depend>
-  
+  <depend>gazebo_ros_control</depend>
+
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
 

--- a/carpincho_simulation/urdf/carpincho.gazebo.xacro
+++ b/carpincho_simulation/urdf/carpincho.gazebo.xacro
@@ -16,16 +16,16 @@
 
   <xacro:friction reference="front_right_wheel" mu="100"/>
   <xacro:friction reference="front_left_wheel" mu="100"/>
-  <xacro:friction reference="rear_caster_base_link" mu="0.05"/>
-
-<!-- ROS Control not supported(yet)  -->
-
-  <!--
+  <xacro:friction reference="rear_caster_wheel_link" mu="0.05"/>
+  
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+        <!-- <robotNamespace>: The ROS namespace to be used for this instance of the plugin, defaults to robot name in URDF/SDF -->
+        <!-- <controlPeriod>: The period of the controller update (in seconds), defaults to Gazebo's period -->
+        <!-- <robotParam>: The location of the robot_description (URDF) on the parameter server, defaults to /robot_description' -->
+        <!-- <robotSimType>: The pluginlib name of a custom robot sim interface to be used, defaults to 'DefaultRobotHWSim' -->
     </plugin>
   </gazebo>
-  -->
 
 
 </robot>


### PR DESCRIPTION
## Summary

This PR:

- Adds the `gazebo_ros_control` package (automatically installed in the `build` process since is a dependency)
- Add a `config` file for the PID values for Gazebo ROS control
- Add a launch file for teleop the robot 

## Known issue

The `PID` values are set to `p=1` because higher values make the robot crash, after doing some testing it seems that higher `mass` on the base solves the issue, indicating that maybe something in the inertia part is not behaving correctly.

The inertia matrix used seems correct, but the value itself `mass=0.8` seems too light for the controller to work properly, I would like to know if this value is correct and is accounting to the rest of the components (battery, board, etc).

A higher mass allows the PID to be tuned and the robot to work much better using `teleop`.

Image of the Robot in `crashed` state:

![Screenshot from 2023-03-26 21-40-26](https://user-images.githubusercontent.com/53347092/227820811-9ccda818-f486-4715-bd65-88ecee9d62de.png)
