### PR TITLE
Add documentation to simulation related items 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ TODO: Add Carpincho description and motivation
 - [`carpincho_base`](./carpincho_base): [ROS Control hardware interface](http://wiki.ros.org/ros_control/Tutorials/Create%20your%20own%20hardware%20interface) is implemented.
 - [`carpincho_control`](./carpincho_control/): It launches the [`controller_manager`](http://wiki.ros.org/controller_manager) for the real robot and loads up the diff_drive_controller and the joint_state_controller.
 - [`carpincho_bringup`](./carpincho_bringup): Contains mainly launch files in order to launch all related driver and nodes to be used in the real robot.
+- [`carpincho_simulation`](./carpincho_simulation): Contains the files to launch the Robot with Gazebo.
+- [`docker`](./docker): Contains the scripts to build and run a docker container with Gazebo and ROS.
 
 ## Hardware
 

--- a/carpincho_simulation/README.md
+++ b/carpincho_simulation/README.md
@@ -1,0 +1,27 @@
+# carpincho_simulation
+
+## Description
+
+This packages is in charge launching a Gazebo simulation using the [`URDF`](http://wiki.ros.org/urdf) file provided by 
+[`carpincho_description`](../carpincho_description/) package.
+
+It uses the same controllers as the real robot by running with [`gazebo_ros_control`](http://wiki.ros.org/gazebo_ros_control).
+
+## Usage
+To launch the Carpincho simulation environment run the [`bringup.launch`](launch/bringup.launch) file:
+
+```sh
+roslaunch carpincho_simulation bringup.launch
+```
+
+To have a better idea on the arguments that you can pass to the [`bringup.launch`](launch/bringup.launch) file, you can use:
+
+```sh
+roslaunch --ros-args carpincho_simulation bringup.launch
+```
+
+To launch the teleop run the [`teleop.launch`](../carpincho_bringup/launch/teleop.launch) file:
+
+```sh
+roslaunch carpincho_bringup teleop.launch
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,61 @@
+# docker
+
+## Description
+
+This folder contains the necessary files to build and run a [`docker`](https://www.docker.com/) container with Gazebo11 and ROS Noetic.
+
+## Instructions
+
+### Prerequisites
+
+It is a requirement to have `docker engine` already installed in the host machine.
+
+* See [Docker Installation Guide](https://docs.docker.com/engine/install/ubuntu/)
+
+For NVIDIA GPU support, `nvidia-container-toolkit` should be installed. *Skip this step if you don't have an NVIDIA graphics card*
+
+
+* Make sure you have the drivers installed:
+  ```sh
+  nvidia-smi
+  ```
+* See [NVIDIA Container Toolkit Installation Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+
+### Building image and running container
+
+- Build the docker image whose name is `ros_melodic`:
+
+```sh
+./docker/build.sh
+```
+
+You can also try to set a specific image name:
+
+```sh
+./docker/build.sh -i my_fancy_image_name
+```
+
+- Run a docker container called `carpincho-sim`:
+
+```sh
+./docker/run.sh
+```
+
+- **IMPORTANT**: If you are using nvidia drivers add the `--use_nvidia` flag:
+
+```sh
+./docker/run.sh --use_nvidia
+```
+
+You can also try to set specific image and container names:
+
+```sh
+./docker/run.sh -i my_fancy_image_name -c my_fancy_container_name
+```
+
+- Build the workspace:
+
+```sh
+catkin_make
+```


### PR DESCRIPTION
## Summary

**NOTE:** Depends on the following one:  [Add ros_control to the simulation](https://github.com/ekumenlabs/carpinchobot/pull/28)

This PR:

- Adds documentation to the `docker` folder
- Adds documentation to the `carpincho_simulation` package