### PR TITLE
Fixes teleop keyboard launch file

### DIFF
--- a/carpincho_bringup/launch/teleop_keyboard.launch.py
+++ b/carpincho_bringup/launch/teleop_keyboard.launch.py
@@ -36,7 +36,9 @@ def generate_launch_description():
             package='teleop_twist_keyboard',
             executable='teleop_twist_keyboard',
             name='teleop_twist_keyboard_node',
-            remappings=[('/cmd_vel','/cmd_vel_keyboard')]
+            remappings=[('/cmd_vel','/cmd_vel_keyboard')],
+            output='screen',
+            prefix = 'xterm -e',
          )
 
     return LaunchDescription([

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -22,3 +22,4 @@ python3-setuptools
 software-properties-common
 sudo
 tmux
+xterm


### PR DESCRIPTION
Running teleop_twist_keyboard via launch file isn't as straight forward given that the following error is thrown:
" Inappropriate ioctl for device"

I added a xterm prefix so as to have a dedicated input/ouput device for the teleop. 