### PR TITLE
Fixes xacro file starting with a comment.

### DIFF
--- a/andino_description/urdf/include/andino_caster_macro.urdf.xacro
+++ b/andino_description/urdf/include/andino_caster_macro.urdf.xacro
@@ -1,10 +1,8 @@
-<!--
-  Xacro macros were inspired on https://github.com/ros-mobile-robots/mobile_robot_description/wiki/ 
--->
-
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-
+<!--
+  Xacro macros were inspired on https://github.com/ros-mobile-robots/mobile_robot_description/wiki/
+-->
 <!-- ===================== Caster xacro =========================================
 
   Xacro to create caster links and the respective joints.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a bug introduced at https://github.com/Ekumen-OS/andino/pull/83#issuecomment-1620774875

## Summary
XACRO files can't start with a comment.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
