### PR TITLE
Fix wrong if/unless wheel xacro

### DIFF
--- a/andino_description/urdf/include/common_macros.urdf.xacro
+++ b/andino_description/urdf/include/common_macros.urdf.xacro
@@ -29,9 +29,9 @@
           <xacro:if value="${wheel_props['scale'] == '' }" >
             <mesh filename="package://andino_description/meshes/${robot_name}/${wheel_props['mesh']}" />
           </xacro:if>
-          <xacro:if value="${wheel_props['scale'] == '' }" >
+          <xacro:unless value="${wheel_props['scale'] == '' }" >
             <mesh filename="package://andino_description/meshes/${robot_name}/${wheel_props['mesh']}" scale="${wheel_props['scale']}" />
-          </xacro:if>
+          </xacro:unless>
         </geometry>
         <material name="dark_grey"/>
       </visual>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://github.com/Ekumen-OS/andino/blob/humble/CONTRIBUTING.md
-->

# 🦟 Bug fix

Fixes #94 

## Summary
- Wheel meshes are added twice when the scale is not defined because of an error in the `common_xacros.urdf.xacro` (same condition is used twice)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

