### PR TITLE
Move pin definitions to hw.h header file

### DIFF
--- a/andino_firmware/src/encoder_driver.cpp
+++ b/andino_firmware/src/encoder_driver.cpp
@@ -69,6 +69,7 @@
 
 #include "Arduino.h"
 #include "commands.h"
+#include "hw.h"
 
 volatile long left_enc_pos = 0L;
 volatile long right_enc_pos = 0L;
@@ -92,6 +93,28 @@ ISR(PCINT1_vect) {
   enc_last |= (PINC & (3 << 4)) >> 4;  // read the current state into lowest 2 bits
 
   right_enc_pos += ENC_STATES[(enc_last & 0x0f)];
+}
+
+void initEncoders() {
+  // set as inputs
+  DDRD &= ~(1 << LEFT_ENCODER_A_GPIO_PIN);
+  DDRD &= ~(1 << LEFT_ENCODER_B_GPIO_PIN);
+  DDRC &= ~(1 << RIGHT_ENCODER_A_GPIO_PIN);
+  DDRC &= ~(1 << RIGHT_ENCODER_B_GPIO_PIN);
+
+  // enable pull up resistors
+  PORTD |= (1 << LEFT_ENCODER_A_GPIO_PIN);
+  PORTD |= (1 << LEFT_ENCODER_B_GPIO_PIN);
+  PORTC |= (1 << RIGHT_ENCODER_A_GPIO_PIN);
+  PORTC |= (1 << RIGHT_ENCODER_B_GPIO_PIN);
+
+  // tell pin change mask to listen to left encoder pins
+  PCMSK2 |= (1 << LEFT_ENCODER_A_GPIO_PIN) | (1 << LEFT_ENCODER_B_GPIO_PIN);
+  // tell pin change mask to listen to right encoder pins
+  PCMSK1 |= (1 << RIGHT_ENCODER_A_GPIO_PIN) | (1 << RIGHT_ENCODER_B_GPIO_PIN);
+
+  // enable PCINT1 and PCINT2 interrupt in the general interrupt mask
+  PCICR |= (1 << PCIE1) | (1 << PCIE2);
 }
 
 /* Wrap the encoder reading function */

--- a/andino_firmware/src/encoder_driver.h
+++ b/andino_firmware/src/encoder_driver.h
@@ -63,15 +63,7 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// below can be changed, but should be PORTD pins;
-// otherwise additional changes in the code are required
-#define LEFT_ENC_PIN_A PD2  // pin 2
-#define LEFT_ENC_PIN_B PD3  // pin 3
-
-// below can be changed, but should be PORTC pins
-#define RIGHT_ENC_PIN_A PC4  // pin A4
-#define RIGHT_ENC_PIN_B PC5  // pin A5
-
+void initEncoders();
 long readEncoder(int i);
 void resetEncoder(int i);
 void resetEncoders();

--- a/andino_firmware/src/hw.h
+++ b/andino_firmware/src/hw.h
@@ -1,0 +1,68 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef ANDINO_FIRMWARE_SRC_HW_H_
+#define ANDINO_FIRMWARE_SRC_HW_H_
+
+// PC4 (pin A4), RIGHT ENCODER PIN A
+#define RIGHT_ENCODER_A_GPIO_PIN PC4
+
+// PC5 (pin A5), RIGHT ENCODER PIN B
+#define RIGHT_ENCODER_B_GPIO_PIN PC5
+
+// PD2 (pin 2), LEFT ENCODER PIN A
+#define LEFT_ENCODER_A_GPIO_PIN PD2
+
+// PD3 (pin 3), LEFT ENCODER PIN B
+#define LEFT_ENCODER_B_GPIO_PIN PD3
+
+// PD5 (pin 5), RIGHT MOTOR DRIVER BACKWARD PIN
+#define RIGHT_MOTOR_BACKWARD_GPIO_PIN 5
+
+// PD6 (pin 6), LEFT MOTOR DRIVER BACKWARD PIN
+#define LEFT_MOTOR_BACKWARD_GPIO_PIN 6
+
+// PB1 (pin 9), RIGHT MOTOR DRIVER FORWARD PIN
+#define RIGHT_MOTOR_FORWARD_GPIO_PIN 9
+
+// PB2 (pin 10), LEFT MOTOR DRIVER FORWARD PIN
+#define LEFT_MOTOR_FORWARD_GPIO_PIN 10
+
+// PB4 (pin 12), RIGHT MOTOR DRIVER ENABLE PIN
+#define RIGHT_MOTOR_ENABLE_GPIO_PIN 12
+
+// PB5 (pin 13), LEFT MOTOR DRIVER ENABLE PIN
+#define LEFT_MOTOR_ENABLE_GPIO_PIN 13
+
+// Note: In order to save two pins, the motor driver enable pins could be
+// directly jumped to 5V in case your L298N motor driver board has a jumper to
+// do so.
+
+#endif  // ANDINO_FIRMWARE_SRC_HW_H_

--- a/andino_firmware/src/main.cpp
+++ b/andino_firmware/src/main.cpp
@@ -231,26 +231,7 @@ int runCommand() {
 void setup() {
   Serial.begin(BAUDRATE);
 
-  // Initialize the motor controller
-  // set as inputs
-  DDRD &= ~(1 << LEFT_ENC_PIN_A);
-  DDRD &= ~(1 << LEFT_ENC_PIN_B);
-  DDRC &= ~(1 << RIGHT_ENC_PIN_A);
-  DDRC &= ~(1 << RIGHT_ENC_PIN_B);
-
-  // enable pull up resistors
-  PORTD |= (1 << LEFT_ENC_PIN_A);
-  PORTD |= (1 << LEFT_ENC_PIN_B);
-  PORTC |= (1 << RIGHT_ENC_PIN_A);
-  PORTC |= (1 << RIGHT_ENC_PIN_B);
-
-  // tell pin change mask to listen to left encoder pins
-  PCMSK2 |= (1 << LEFT_ENC_PIN_A) | (1 << LEFT_ENC_PIN_B);
-  // tell pin change mask to listen to right encoder pins
-  PCMSK1 |= (1 << RIGHT_ENC_PIN_A) | (1 << RIGHT_ENC_PIN_B);
-
-  // enable PCINT1 and PCINT2 interrupt in the general interrupt mask
-  PCICR |= (1 << PCIE1) | (1 << PCIE2);
+  initEncoders();
   initMotorController();
   resetPID();
 }

--- a/andino_firmware/src/motor_driver.cpp
+++ b/andino_firmware/src/motor_driver.cpp
@@ -67,10 +67,11 @@
 
 #include "Arduino.h"
 #include "commands.h"
+#include "hw.h"
 
 void initMotorController() {
-  digitalWrite(RIGHT_MOTOR_ENABLE, HIGH);
-  digitalWrite(LEFT_MOTOR_ENABLE, HIGH);
+  digitalWrite(RIGHT_MOTOR_ENABLE_GPIO_PIN, HIGH);
+  digitalWrite(LEFT_MOTOR_ENABLE_GPIO_PIN, HIGH);
 }
 
 void setMotorSpeed(int i, int spd) {
@@ -84,19 +85,19 @@ void setMotorSpeed(int i, int spd) {
 
   if (i == LEFT) {
     if (forward) {
-      analogWrite(LEFT_MOTOR_FORWARD, spd);
-      analogWrite(LEFT_MOTOR_BACKWARD, 0);
+      analogWrite(LEFT_MOTOR_FORWARD_GPIO_PIN, spd);
+      analogWrite(LEFT_MOTOR_BACKWARD_GPIO_PIN, 0);
     } else {
-      analogWrite(LEFT_MOTOR_BACKWARD, spd);
-      analogWrite(LEFT_MOTOR_FORWARD, 0);
+      analogWrite(LEFT_MOTOR_BACKWARD_GPIO_PIN, spd);
+      analogWrite(LEFT_MOTOR_FORWARD_GPIO_PIN, 0);
     }
   } else /*if (i == RIGHT) //no need for condition*/ {
     if (forward) {
-      analogWrite(RIGHT_MOTOR_FORWARD, spd);
-      analogWrite(RIGHT_MOTOR_BACKWARD, 0);
+      analogWrite(RIGHT_MOTOR_FORWARD_GPIO_PIN, spd);
+      analogWrite(RIGHT_MOTOR_BACKWARD_GPIO_PIN, 0);
     } else {
-      analogWrite(RIGHT_MOTOR_BACKWARD, spd);
-      analogWrite(RIGHT_MOTOR_FORWARD, 0);
+      analogWrite(RIGHT_MOTOR_BACKWARD_GPIO_PIN, spd);
+      analogWrite(RIGHT_MOTOR_FORWARD_GPIO_PIN, 0);
     }
   }
 }

--- a/andino_firmware/src/motor_driver.h
+++ b/andino_firmware/src/motor_driver.h
@@ -63,16 +63,6 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#define RIGHT_MOTOR_BACKWARD 5
-#define LEFT_MOTOR_BACKWARD  6
-#define RIGHT_MOTOR_FORWARD  9
-#define LEFT_MOTOR_FORWARD   10
-// The RIGHT_MOTOR_ENABLE and LEFT_MOTOR_ENABLE pins can be jumped
-// to 5V directly in case your Motor Driver Board has a jumper to do this.
-// This way two pins are saved.
-#define RIGHT_MOTOR_ENABLE 12
-#define LEFT_MOTOR_ENABLE  13
-
 void initMotorController();
 void setMotorSpeed(int i, int spd);
 void setMotorSpeeds(int leftSpeed, int rightSpeed);


### PR DESCRIPTION
# 🎉 New feature

Related: #87 

## Summary
This PR moves all the pin definitions into a header file called `hw.h`. This helps to decouple the software logic from the hardware connections, thus making it easier to reassign pins if needed (further changes are still required to ensure nothing breaks when pins are reassigned).

This PR also moves the encoder GPIO initialization into a new init function within said module.

This is the first of several PRs that will improve the code structure.

## Test it
N/A.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
