### PR TITLE
Adds andino_control as dependency of andino_gazebo

### DIFF
--- a/andino_gazebo/package.xml
+++ b/andino_gazebo/package.xml
@@ -21,7 +21,6 @@
 
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
-  <exec_depend>ros2_control</exec_depend>
 
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/andino_gazebo/package.xml
+++ b/andino_gazebo/package.xml
@@ -18,15 +18,11 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-  
+
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
-  <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>ros2_control</exec_depend>
-  <exec_depend>ros2_controllers</exec_depend>
 
-  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
 

--- a/andino_gazebo/package.xml
+++ b/andino_gazebo/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>andino_control</exec_depend>
   <exec_depend>andino_description</exec_depend>
   <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #117 

## Summary
What the title says

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)


