### PR TITLE
Parametrize config yaml path in andino.urdf.xacro

### DIFF
--- a/andino_description/urdf/andino.urdf.xacro
+++ b/andino_description/urdf/andino.urdf.xacro
@@ -8,23 +8,23 @@
   <xacro:include filename="$(find ${package_name})/urdf/include/common_sensors.urdf.xacro" />
   <xacro:include filename="$(find ${package_name})/urdf/include/andino_caster_macro.urdf.xacro" />
 
-  <xacro:arg name="config_yaml_path" default="$(find ${package_name})/config/${robot_name}" />
+  <xacro:arg name="yaml_config_dir" default="$(find ${package_name})/config/${robot_name}" />
 
-  <xacro:property name="caster_wheel_yaml" value="$(arg config_yaml_path)/caster_wheel.yaml" />
+  <xacro:property name="caster_wheel_yaml" value="$(arg yaml_config_dir)/caster_wheel.yaml" />
   <xacro:property name="caster_wheel_props" value="${xacro.load_yaml(caster_wheel_yaml)}"/>
   <xacro:arg name="use_fixed_caster" default="True"/>
   <xacro:arg name="use_real_ros_control" default="True"/>
 
-  <xacro:property name="wheel_yaml" value="$(arg config_yaml_path)/wheel.yaml" />
+  <xacro:property name="wheel_yaml" value="$(arg yaml_config_dir)/wheel.yaml" />
   <xacro:property name="wheel_props" value="${xacro.load_yaml(wheel_yaml)}"/>
 
-  <xacro:property name="motor_yaml" value="$(arg config_yaml_path)/motor.yaml" />
+  <xacro:property name="motor_yaml" value="$(arg yaml_config_dir)/motor.yaml" />
   <xacro:property name="motor_props" value="${xacro.load_yaml(motor_yaml)}"/>
 
-  <xacro:property name="base_yaml" value="$(arg config_yaml_path)/base.yaml" />
+  <xacro:property name="base_yaml" value="$(arg yaml_config_dir)/base.yaml" />
   <xacro:property name="base_props" value="${xacro.load_yaml(base_yaml)}"/>
 
-  <xacro:property name="sensor_yaml" value="$(arg config_yaml_path)/sensors.yaml" />
+  <xacro:property name="sensor_yaml" value="$(arg yaml_config_dir)/sensors.yaml" />
   <xacro:property name="sensor_prop" value="${xacro.load_yaml(sensor_yaml)}"/>
 
   <!-- Footprint link -->


### PR DESCRIPTION
# 🎉 New feature

Related #135 

## Summary
This PR parametrizes the configuration yaml files path in the `andino.urdf.xacro` file as a first step to load custom configuration files for the andino description.

If no argument is passed down to the xacro files, it will use the current path as default (`andino_description/config/andino/`).

The xacro file would expect to find **all** configuration files (base, caster_wheel, motor, sensors, wheel) at the new path. 

## Test it
<!--Explain how reviewers can test this new feature manually.-->
To test this manually, add all the necessary configuration files and generate the urdf file using the xacro CLI with the following command:
`xacro src/andino/andino_description/urdf/andino.urdf.xacro config_yaml_path:=<path_to_config_files> > <output_file>`


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
