### PR TITLE
Fix Gazebo friction reference

### DIFF
--- a/andino_gazebo/urdf/andino.gazebo.xacro
+++ b/andino_gazebo/urdf/andino.gazebo.xacro
@@ -14,8 +14,8 @@
     </gazebo>
   </xacro:macro>
 
-  <xacro:friction reference="front_right_wheel" mu="100.0"/>
-  <xacro:friction reference="front_left_wheel" mu="100.0"/>
+  <xacro:friction reference="right_wheel" mu="100.0"/>
+  <xacro:friction reference="left_wheel" mu="100.0"/>
   <xacro:friction reference="caster_wheel_link" mu="0.05"/>
   <!--TODO(olmerg) initial solution problem with ros control  -->
   <!-- <xacro:friction reference="caster_rotation_link" mu="0.0"/> -->


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://github.com/Ekumen-OS/andino/blob/humble/CONTRIBUTING.md
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The Gazebo reference for the friction value was pointing incorrectly to a link in the format `front_<direction>_wheel` instead of `<direction>_wheel`.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.