### PR TITLE
Fix media link

### DIFF
--- a/andino_description/urdf/andino.urdf.xacro
+++ b/andino_description/urdf/andino.urdf.xacro
@@ -8,21 +8,23 @@
   <xacro:include filename="$(find ${package_name})/urdf/include/common_sensors.urdf.xacro" />
   <xacro:include filename="$(find ${package_name})/urdf/include/andino_caster_macro.urdf.xacro" />
 
-  <xacro:property name="caster_wheel_yaml" value="$(find ${package_name})/config/${robot_name}/caster_wheel.yaml" />
+  <xacro:arg name="yaml_config_dir" default="$(find ${package_name})/config/${robot_name}" />
+
+  <xacro:property name="caster_wheel_yaml" value="$(arg yaml_config_dir)/caster_wheel.yaml" />
   <xacro:property name="caster_wheel_props" value="${xacro.load_yaml(caster_wheel_yaml)}"/>
   <xacro:arg name="use_fixed_caster" default="True"/>
   <xacro:arg name="use_real_ros_control" default="True"/>
 
-  <xacro:property name="wheel_yaml" value="$(find ${package_name})/config/${robot_name}/wheel.yaml" />
+  <xacro:property name="wheel_yaml" value="$(arg yaml_config_dir)/wheel.yaml" />
   <xacro:property name="wheel_props" value="${xacro.load_yaml(wheel_yaml)}"/>
 
-  <xacro:property name="motor_yaml" value="$(find ${package_name})/config/${robot_name}/motor.yaml" />
+  <xacro:property name="motor_yaml" value="$(arg yaml_config_dir)/motor.yaml" />
   <xacro:property name="motor_props" value="${xacro.load_yaml(motor_yaml)}"/>
 
-  <xacro:property name="base_yaml" value="$(find ${package_name})/config/${robot_name}/base.yaml" />
+  <xacro:property name="base_yaml" value="$(arg yaml_config_dir)/base.yaml" />
   <xacro:property name="base_props" value="${xacro.load_yaml(base_yaml)}"/>
 
-  <xacro:property name="sensor_yaml" value="$(find ${package_name})/config/${robot_name}/sensors.yaml" />
+  <xacro:property name="sensor_yaml" value="$(arg yaml_config_dir)/sensors.yaml" />
   <xacro:property name="sensor_prop" value="${xacro.load_yaml(sensor_yaml)}"/>
 
   <!-- Footprint link -->


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The media section contains an emoji that disables auto-scroll when using a link right after the logo. This PR removes the emoji to re-enable auto-scrolling when clicking on the link.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.