### PR TITLE
Provides info about joy teleoperation.

### DIFF
--- a/andino_bringup/launch/teleop_joystick.launch.py
+++ b/andino_bringup/launch/teleop_joystick.launch.py
@@ -32,11 +32,19 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
     joystick_config = os.path.join(get_package_share_directory('andino_bringup'),'config','joystick.yaml')
+
+    cmd_vel_topic_arg = DeclareLaunchArgument(
+            'cmd_vel_topic',
+            default_value='/cmd_vel_joy',
+            description='Indicates the cmd_vel topic.')
+    cmd_vel_topic =  LaunchConfiguration('cmd_vel_topic')
 
     joy_linux_node = Node(
             package='joy_linux',
@@ -49,10 +57,11 @@ def generate_launch_description():
             executable='teleop_node',
             name='teleop_node',
             parameters=[joystick_config],
-            remappings=[('/cmd_vel','/cmd_vel_joy')]
+            remappings=[('/cmd_vel', cmd_vel_topic)]
          )
 
     return LaunchDescription([
+        cmd_vel_topic_arg,
         joy_linux_node,
         teleop_node,
     ])

--- a/andino_hardware/README.md
+++ b/andino_hardware/README.md
@@ -225,3 +225,23 @@ TLDR? Export an environment variable with the same ID in **all** ROS 2 clients i
 ```
 export ROS_DOMAIN_ID=<a_number_between_0_and_101>
 ```
+
+#### Using joystick for teleoperation
+
+[`andino_bringup`](../andino_bringup/launch/teleop_joystick.launch.py) package provides a launch file for launching the corresponding `ROS 2` nodes for teleoperating the robot using a joystick.
+
+It is worth mentioning that a set up might be needed depending on the gamepad you are using. Here some general guidelines:
+ - In case you are using a _Xbox One Controller_ and you want use it wireless (via USB Wirless Dongle) installing [Xone](https://github.com/medusalix/xone) is recommended.
+ - Verify that your joystick is actually working on Ubuntu:
+    - Some tools that might be useful:
+      - `sudo apt install joystick jstest-gtk evtest`
+    - Run `evtest` to check if your pad is connected:
+      ```
+      $ evtest
+        No device specified, trying to scan all of /dev/input/event*
+        Not running as root, no devices may be available.
+        Available devices:
+          /dev/input/event22:	Microsoft X-Box One pad
+
+      ```
+    - Alternatively, you can use `jstest-gtk` to check the controller, you will find a pretty GUI to play with.


### PR DESCRIPTION
# 🎉 New feature

## Summary
- Provides information about joystick configuration for robot teleoperation
- Adds an argument to the launch file that sets up the joy nodes for allowing to change the cmd_vel topic.

## Test it

```
ros2 launch andino_gazebo andino_one_robot.launch.py 
```
```
ros2 launch andino_bringup teleop_joystick.launch.py cmd_vel_topic:=cmd_vel
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

