### PR TITLE
Fixes USB port names

### DIFF
--- a/andino_bringup/launch/andino_robot.launch.py
+++ b/andino_bringup/launch/andino_robot.launch.py
@@ -81,6 +81,7 @@ def generate_launch_description():
             os.path.join(pkg_andino_bringup, 'launch', 'rplidar.launch.py'),
         ),
         launch_arguments={
+            "serial_port": '/dev/ttyUSB_LIDAR',
         }.items(),
                 condition=IfCondition(rplidar)
     )

--- a/andino_bringup/launch/rplidar.launch.py
+++ b/andino_bringup/launch/rplidar.launch.py
@@ -36,7 +36,7 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     channel_type =  LaunchConfiguration('channel_type', default='serial')
-    serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB1')
+    serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB_LIDAR')
     serial_baudrate = LaunchConfiguration('serial_baudrate', default='115200')
     frame_id = LaunchConfiguration('frame_id', default='rplidar_laser_link')
     inverted = LaunchConfiguration('inverted', default='false')
@@ -91,5 +91,7 @@ def generate_launch_description():
                          'inverted': inverted,
                          'scan_mode': scan_mode,
                          'angle_compensate': angle_compensate}],
-            output='screen'),
+            output='screen',
+            remappings=[('scan', 'scan')]
+            ),
     ])

--- a/andino_description/urdf/include/andino_control.urdf.xacro
+++ b/andino_description/urdf/include/andino_control.urdf.xacro
@@ -8,7 +8,7 @@
       <!-- TODO(francocipollone): Parameters like loop_rate, device, baud_rate, etc should be loaded from a file or passed via the launch file as xacro args -->
       <param name="left_wheel_name">left_wheel_joint</param>
       <param name="right_wheel_name">right_wheel_joint</param>
-      <param name="serial_device">/dev/ttyUSB0</param>
+      <param name="serial_device">/dev/ttyUSB_ARDUINO</param>
       <param name="baud_rate">57600</param>
       <param name="timeout">1000</param>
       <param name="enc_ticks_per_rev">585</param>

--- a/andino_hardware/README.md
+++ b/andino_hardware/README.md
@@ -190,6 +190,91 @@ source install/setup.bash
 After this, you are good to go and use the robot!
 Refer to [`usage`](../README.md#usage) section.
 
+### USB Port name configuration
+
+#### Fixed USB port names
+
+As having multiple USB devices connected to the USB ports of the Raspberry Pi, the automatically assigned USB port numbers could unexpectedly change after a reboot.
+To avoid assigning your device to a `tty_USBX` number that isn't the correct onew we should assign fixed USB port name for each connected device.
+
+The idea is to be able to generate a link between the real `ttyUSBX` port and an invented one. For this we will need to create rules, that every time the Raspberry Pi boots are executed, and therefore we
+always point to the correct port name.
+
+In order to create fixed names for the USB devices follow the instructions:
+
+1. Check the devices you have connected:
+    ```
+    sudo dmesg | grep ttyUSB
+    ```
+
+    ```
+    [  10.016170] usb 1-1.2: ch341-uart converter now attached to ttyUSB0
+    [ 309.186487] usb 1-1.1: cp210x converter now attached to ttyUSB1
+    ```
+    In the setup where this was tested we have:
+      -> Arduino Microcontroller -> _usb 1-1.2: ch341-uart converter now attached to ttyUSB0_
+      -> A1M8 Lidar Scanner -> _usb 1-1.1: cp210x converter now attached to ttyUSB1_
+
+    _Note: If you don't know how to identify each one you can simply connect them one by one and check this output._
+
+2. Look for attributes for each device that we will use to anchor a particular device with a name.
+  We will use the `idProduct` and `idVendor` of each device.
+   - Arduino Microcontroller:
+      ```
+      udevadm info --name=/dev/ttyUSB0 --attribute-walk
+      ```
+      You should look for the `idProduct` and `idVendor` under the category that matches the usb number(1-1.X):
+      In this case the `ttyUSB0` was referenced to the `usb 1-1.2`, so go to that section and find the ids:
+      ```
+        ATTRS{idProduct}=="7523"
+        ATTRS{idVendor}=="1a86"
+      ```
+   - Lidar Scanner
+      ```
+      udevadm info --name=/dev/ttyUSB1 --attribute-walk
+      ```
+      In this case the `ttyUSB0` was referenced to the `usb 1-1.1`, so go to that section and find the ids:
+      ```
+        ATTRS{idProduct}=="ea60"
+        ATTRS{idVendor}=="10c4"
+      ```
+
+3. Create the rules:
+
+    Open the file:
+    ```
+    sudo nano /etc/udev/rules.d/10-usb-serial.rules
+    ```
+
+    Add the following:
+
+    ```
+    SUBSYSTEM=="tty", ATTRS{idProduct}=="7523", ATTRS{idVendor}=="1a86", SYMLINK+="ttyUSB_ARDUINO"
+    SUBSYSTEM=="tty", ATTRS{idProduct}=="ea60", ATTRS{idVendor}=="10c4", SYMLINK+="ttyUSB_LIDAR"
+    ```
+    Note that in the `symlink` field a fixed name is indicated.
+
+4. Re-trigger the device manager:
+    ```
+    sudo udevadm trigger
+    ```
+
+5. Verify
+    ```
+    ls -l /dev/ttyUSB*
+    ```
+    ```
+    crw-rw---- 1 root dialout 188, 0 Sep  2 15:09 /dev/ttyUSB0
+    crw-rw---- 1 root dialout 188, 1 Sep  2 15:09 /dev/ttyUSB1
+    lrwxrwxrwx 1 root root         7 Sep  2 15:09 /dev/ttyUSB_ARDUINO -> ttyUSB0
+    lrwxrwxrwx 1 root root         7 Sep  2 15:09 /dev/ttyUSB_LIDAR -> ttyUSB1
+    ```
+
+Done! You can always use your devices by the fixed names without using the port number.
+Here, `ttyUSB_ARDUINO` and `ttyUSB_LIDAR` are fixed names for the Arduino Microcontroller and the Lidar Scanner respectively.
+
+For more information you can take a look at this external tutorial: [Here](https://www.freva.com/assign-fixed-usb-port-names-to-your-raspberry-pi/)
+
 ### Extra Recommendations & Tools
 
 #### Network

--- a/andino_hardware/README.md
+++ b/andino_hardware/README.md
@@ -154,42 +154,6 @@ For now, after connecting it to the usb port:
     - `ls -l /dev |grep ttyUSB`
     - Add extra bits by doing `sudo chmod 666 /dev/ttyUSB<number_of_device>`
 
-### Create robot workspace
-
-Let's create our workspace and build from source this repository.
-
-```
-cd ~
-```
-```
-mkdir robot_ws/src -p
-```
-Clone this repository in the `src` folder
-```
-cd robot_ws/src
-```
-```
-git clone <repository_address>
-```
-Install dependencies via rosdep:
-```
-cd ~/robot_ws
-```
-```
-rosdep install --from-paths src -i -y
-```
-Let's build the packages.
-```
-colcon build
-```
-After building is completed:
-```
-source install/setup.bash
-```
-
-After this, you are good to go and use the robot!
-Refer to [`usage`](../README.md#usage) section.
-
 ### USB Port name configuration
 
 #### Fixed USB port names
@@ -274,6 +238,42 @@ Done! You can always use your devices by the fixed names without using the port 
 Here, `ttyUSB_ARDUINO` and `ttyUSB_LIDAR` are fixed names for the Arduino Microcontroller and the Lidar Scanner respectively.
 
 For more information you can take a look at this external tutorial: [Here](https://www.freva.com/assign-fixed-usb-port-names-to-your-raspberry-pi/)
+
+### Create robot workspace
+
+Let's create our workspace and build from source this repository.
+
+```
+cd ~
+```
+```
+mkdir robot_ws/src -p
+```
+Clone this repository in the `src` folder
+```
+cd robot_ws/src
+```
+```
+git clone <repository_address>
+```
+Install dependencies via rosdep:
+```
+cd ~/robot_ws
+```
+```
+rosdep install --from-paths src -i -y
+```
+Let's build the packages.
+```
+colcon build
+```
+After building is completed:
+```
+source install/setup.bash
+```
+
+After this, you are good to go and use the robot!
+Refer to [`usage`](../README.md#usage) section.
 
 ### Extra Recommendations & Tools
 


### PR DESCRIPTION
# 🎉 New feature

Closes #45 

## Summary
 - Fixes USB port names to 
   - ttyUSB_ARDUINO: For the arduino device
   - ttyUSB_LIDAR: For the lidar scanner device.
 - Adds documentation.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

