### PR TITLE
Adds a laser range filter for the laser scan messages.

### DIFF
--- a/andino_bringup/config/laser_range_filter.yaml
+++ b/andino_bringup/config/laser_range_filter.yaml
@@ -1,0 +1,11 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    filter1:
+      name: box_filter
+      type: laser_filters/LaserScanRangeFilter
+      params:
+        use_message_range_limits: false   # if not specified defaults to false
+        lower_threshold: 0.5              # if not specified defaults to 0.0
+        upper_threshold: 12.0              # if not specified defaults to 100000.0
+        lower_replacement_value: -.inf    # if not specified defaults to NaN
+        upper_replacement_value: .inf     # if not specified defaults to NaN

--- a/andino_bringup/launch/rplidar.launch.py
+++ b/andino_bringup/launch/rplidar.launch.py
@@ -28,20 +28,24 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     channel_type =  LaunchConfiguration('channel_type', default='serial')
-    serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB1')
+    serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB_LIDAR')
     serial_baudrate = LaunchConfiguration('serial_baudrate', default='115200')
     frame_id = LaunchConfiguration('frame_id', default='rplidar_laser_link')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
     scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    laser_range_filter = LaunchConfiguration('laser_range_filter', default=False)
 
     return LaunchDescription([
 
@@ -79,7 +83,14 @@ def generate_launch_description():
             default_value=scan_mode,
             description='Specifying scan mode of lidar'),
 
-
+        DeclareLaunchArgument(
+            'laser_range_filter',
+            default_value=laser_range_filter,
+            description='Adds a laser range filter in the output.'
+        ),
+        ###############################
+        ## Not using laser range filter.
+        ###############################
         Node(
             package='rplidar_ros',
             executable='rplidar_composition',
@@ -91,5 +102,41 @@ def generate_launch_description():
                          'inverted': inverted,
                          'scan_mode': scan_mode,
                          'angle_compensate': angle_compensate}],
-            output='screen'),
+            output='screen',
+            condition=IfCondition(PythonExpression(['not ', laser_range_filter])),
+            ),
+
+        ###############################
+        ## Using laser range filter
+        ###############################
+        Node(
+            package='rplidar_ros',
+            executable='rplidar_composition',
+            name='rplidar_node',
+            parameters=[{'channel_type':channel_type,
+                         'serial_port': serial_port,
+                         'serial_baudrate': serial_baudrate,
+                         'frame_id': frame_id,
+                         'inverted': inverted,
+                         'scan_mode': scan_mode,
+                         'angle_compensate': angle_compensate}],
+            output='screen',
+            remappings=[('scan', 'scan_raw')],
+            condition=IfCondition(laser_range_filter)
+            ),
+
+        Node(
+            package="laser_filters",
+            executable="scan_to_scan_filter_chain",
+            parameters=[
+                PathJoinSubstitution([
+                    get_package_share_directory("andino_bringup"),
+                    "config", "laser_range_filter.yaml",
+                ])],
+            remappings=[
+              ('scan', 'scan_raw'),
+              ('scan_filtered', 'scan'),
+            ],
+            condition=IfCondition(laser_range_filter)
+        )
     ])

--- a/andino_bringup/package.xml
+++ b/andino_bringup/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>joy_linux</exec_depend>
   <exec_depend>twist_mux</exec_depend>
   <exec_depend>v4l2_camera</exec_depend>
+  <exec_depend>laser_filters</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# 🎉 New feature

## Summary
- Adds an optional filter for the laser scan messages to filter out points that are out of range. It is particularly useful for moving up the lower threshold in case an object is added to the `andino` robot that causes interference with the lasers.
- It is disabled by default.

## Test it
```
ros2 launch andino_bringup rplidar_launch laser_range_filter:=True
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

