### PR TITLE
Make sure to initialize motor speeds

### DIFF
--- a/andino_firmware/src/main.cpp
+++ b/andino_firmware/src/main.cpp
@@ -302,7 +302,8 @@ void loop() {
 
   // Run a PID calculation at the appropriate intervals
   if (millis() > nextPID) {
-    int left_motor_speed, right_motor_speed;
+    int left_motor_speed = 0;
+    int right_motor_speed = 0;
     left_pid_controller.compute(readEncoder(LEFT), left_motor_speed);
     right_pid_controller.compute(readEncoder(RIGHT), right_motor_speed);
     left_motor.set_speed(left_motor_speed);


### PR DESCRIPTION
# 🎉 New feature

## Summary
Under some circumstances, when the microcontroller starts, the variables used when setting the motor speed on the PID loop might have some data, because the PID controller isn't initialized, that variable isn't changed and we pass a value to the motors, which start moving.

## Test it
I found this while porting the code to work on a ESP32, not sure if there's an easy way to reproduce this issue in a regular Arduino.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
