### PR TITLE
Don't send stop constantly

### DIFF
--- a/andino_firmware/src/main.cpp
+++ b/andino_firmware/src/main.cpp
@@ -312,6 +312,7 @@ void loop() {
 
   // Check to see if we have exceeded the auto-stop interval
   if ((millis() - lastMotorCommand) > AUTO_STOP_INTERVAL) {
+    lastMotorCommand = millis();
     left_motor.set_speed(0);
     right_motor.set_speed(0);
     left_pid_controller.enable(false);


### PR DESCRIPTION
# 🎉 New feature

## Summary
Not sure if this is how the firmware is intended to work, but because `lastMotorCommand` is only updated when the firmware receives a new command, if the robot is idle, it will constantly send 0 speed to the motors. This makes sure that we only send 0 speed every `AUTO_STOP_INTERVAL` seconds.

Feel free to ignore and close if the intended behaviour was correct.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
