### PR TITLE
Fixes rosbag2 dependency.

### DIFF
--- a/andino_bringup/package.xml
+++ b/andino_bringup/package.xml
@@ -20,7 +20,7 @@
   <exec_depend>twist_mux</exec_depend>
   <exec_depend>v4l2_camera</exec_depend>
   <exec_depend>laser_filters</exec_depend>
-  <exec_depend>rosbag2-storage-mcap</exec_depend>
+  <exec_depend>rosbag2_storage_mcap</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Dependency to `rosbag2-storage-mcap` package was mistakenly added in #147 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
