### PR TITLE
Removes CMake dependency to controller_manager

### DIFF
--- a/andino_base/CMakeLists.txt
+++ b/andino_base/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
-find_package(controller_manager REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
 

--- a/andino_base/package.xml
+++ b/andino_base/package.xml
@@ -20,7 +20,6 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
-  <exec_depend>joint_state_broadcaster</exec_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
 - controller_manager is a `exec_dependency`, no need to request at CMake level
 - Making source build pass in ROS build farm:
 
 See https://build.ros2.org/job/Hdev__andino__ubuntu_jammy_amd64/1/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

