### PR TITLE
Adds explicit linking of serial library to motor_driver_demo app.

### DIFF
--- a/andino_base/applications/CMakeLists.txt
+++ b/andino_base/applications/CMakeLists.txt
@@ -5,10 +5,14 @@ target_include_directories(motor_driver_demo
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
+# Reference: See libserial example project for integration with CMake
+target_include_directories(motor_driver_demo PUBLIC ${SERIAL_INCLUDE_DIRS})
+
 target_link_libraries(motor_driver_demo
   PUBLIC
     gflags
     motor_driver
+    ${SERIAL_LDFLAGS}
 )
 
 install(


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
 - Undefined references happen when building in ros build farm. https://build.ros2.org/job/Hdev__andino__ubuntu_jammy_amd64/2/console
 
 - This PR adds an explicit linking to serial library. 
 
## Alternatives
 - Creating a pimpl pattern for the MotorDriver class to hide the header file into the implementation would be neat.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
