### PR TITLE
Minor modifications to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: colcon build & test
 
 on:
   push:
+    branches:
+      - humble
   pull_request:
     branches:
       - humble
@@ -9,6 +11,11 @@ on:
 
 env:
   ROS_DISTRO: humble
+
+# Cancel previously running PR jobs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   compile_and_test:


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - CI is only triggered for `pull_request` or pushing to `humble`
    - In case CI for a particular branch is wanted to be run there is the `workflow_dispatch` enabled
 - Cancel old workflows when a new one is triggered due to a new commit. 
    - This is useful for code development and avoid having CI time running when it isn't necessary. 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

