### PR TITLE
Adds pkg-config module dependency

### DIFF
--- a/andino_base/CMakeLists.txt
+++ b/andino_base/CMakeLists.txt
@@ -10,6 +10,11 @@ find_package(hardware_interface REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(pluginlib REQUIRED)
 
+# libserial:
+# Following linking instructions from: https://github.com/crayzeewulf/libserial/blob/master/examples/example_project/CMakeLists.txt
+set(THREADS_HAVE_PTHREAD_ARG 1)
+find_package(Threads REQUIRED)
+
 # Include libserial for serial communication
 # Typical find_package() does not work for libserial, for reference see:
 # https://github.com/crayzeewulf/libserial/issues/113#issuecomment-432245159

--- a/andino_base/applications/CMakeLists.txt
+++ b/andino_base/applications/CMakeLists.txt
@@ -5,14 +5,10 @@ target_include_directories(motor_driver_demo
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-# Reference: See libserial example project for integration with CMake
-target_include_directories(motor_driver_demo PUBLIC ${SERIAL_INCLUDE_DIRS})
-
 target_link_libraries(motor_driver_demo
   PUBLIC
     gflags
     motor_driver
-    ${SERIAL_LDFLAGS}
 )
 
 install(

--- a/andino_base/package.xml
+++ b/andino_base/package.xml
@@ -10,6 +10,7 @@
   <license file="LICENSE">BSD Clause 3</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>hardware_interface</depend>
   <depend>libgflags-dev</depend>

--- a/andino_base/src/CMakeLists.txt
+++ b/andino_base/src/CMakeLists.txt
@@ -7,7 +7,7 @@ target_include_directories(motor_driver
 
 # Reference: See libserial example project for integration with CMake
 target_include_directories(motor_driver PUBLIC ${SERIAL_INCLUDE_DIRS})
-target_link_libraries(motor_driver PUBLIC ${SERIAL_LDFLAGS})
+target_link_libraries(motor_driver PUBLIC ${SERIAL_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT})
 
 
 add_library(diffdrive_andino SHARED diffdrive_andino.cpp wheel.cpp)


### PR DESCRIPTION
# 🦟 Bug fix

Related to #159 

## Summary
 - Adds missing package dependency to `pkg-config`
 - Removes unnecessary explicit linking added at #157 
 - Update cmake installation to link against libserial as it is recommended in the upstream's readme.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
