### PR TITLE
Removes cmake find_package at andino_gz_classic package

### DIFF
--- a/andino_gz_classic/CMakeLists.txt
+++ b/andino_gz_classic/CMakeLists.txt
@@ -2,13 +2,6 @@ cmake_minimum_required(VERSION 3.8)
 
 project(andino_gz_classic)
 
-# Skip if Gazebo not present
-find_package(gazebo QUIET)
-if(NOT gazebo_FOUND)
-  message(WARNING "Gazebo not found, proceeding without that simulator.")
-  return()
-endif()
-
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
 - gazebo isn't being used at build time.
 - removes ros buildfarm warning: https://build.ros2.org/job/Hdev__andino__ubuntu_jammy_amd64/5/cmake/info/

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
