### PR TITLE
gz_classic_sim: Free caster wheel joint.

### DIFF
--- a/andino_gz_classic/launch/spawn_robot.launch.py
+++ b/andino_gz_classic/launch/spawn_robot.launch.py
@@ -70,13 +70,6 @@ def get_robot_description(use_ros_control: str) -> str:
     robot_desc = robot_desc.replace(
         'package://andino_description/', f'file://{folder}/'
     )
-    # TODO(issue #110). Gazebo simulation with ros control and caster wheel working complete
-    # made that the robot do not move in straight-line.
-    # hack to solve the problem of the caster.
-    robot_desc = robot_desc.replace(
-        '<joint name="caster_rotation_joint" type="continuous">',
-        '<joint name="caster_rotation_joint" type="fixed">',
-    )
     return robot_desc
 
 

--- a/andino_gz_classic/urdf/andino_gz_classic.xacro
+++ b/andino_gz_classic/urdf/andino_gz_classic.xacro
@@ -3,24 +3,6 @@
 
   <xacro:include filename="$(find andino_description)/urdf/andino.urdf.xacro"/>
 
-  <xacro:macro name="friction" params="reference mu">
-    <gazebo reference="${reference}">
-      <mu1>${mu}</mu1>
-      <mu2>${mu}</mu2>
-      <kp>1000000.0</kp>
-      <kd>1.0</kd>
-      <minDepth>0.0001</minDepth>
-      <maxVel>1.0</maxVel>
-    </gazebo>
-  </xacro:macro>
-
-  <xacro:friction reference="right_wheel" mu="100.0"/>
-  <xacro:friction reference="left_wheel" mu="100.0"/>
-  <xacro:friction reference="caster_wheel_link" mu="0.05"/>
-  <!--TODO(olmerg) initial solution problem with ros control  -->
-  <!-- <xacro:friction reference="caster_rotation_link" mu="0.0"/> -->
-
-
    <xacro:if value="$(arg use_gazebo_ros_control)">
     <ros2_control name="diff_controller" type="system">
     <hardware>
@@ -52,7 +34,8 @@
         <remapping>~/out:=joint_states</remapping>
         <remapping>/tf:=tf</remapping>
       </ros>
-      <update_rate>10</update_rate>
+      <update_rate>30</update_rate>
+      <joint_name>caster_rotation_joint</joint_name>
       <joint_name>caster_wheel_joint</joint_name>
     </plugin>
     </gazebo>
@@ -65,9 +48,10 @@
         <remapping>~/out:=joint_states</remapping>
         <remapping>/tf:=tf</remapping>
       </ros>
-      <update_rate>10</update_rate>
+      <update_rate>30</update_rate>
       <joint_name>right_wheel_joint</joint_name>
       <joint_name>left_wheel_joint</joint_name>
+      <joint_name>caster_rotation_joint</joint_name>
       <joint_name>caster_wheel_joint</joint_name>
     </plugin>
 


### PR DESCRIPTION
## 🦟 Bug fix

Related to #110 

## Summary
 - Makes caster wheel free in the gazebo classic simulation
 - Publish `rotation_wheel_joint` and `caster_wheel_joint` states tf information
 
 - verified there is no drift in odometry as the counterpart of what was discussed in #110 .
 
https://github.com/Ekumen-OS/andino/assets/53065142/2da2334e-91dc-4038-91ce-cfee3a5308c8

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

