### PR TITLE
Enable all compiler warnings

### DIFF
--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -12,3 +12,5 @@
 platform = atmelavr
 board = uno
 framework = arduino
+build_flags =
+  -Wall -Wextra


### PR DESCRIPTION
# 🎉 New feature

Related: #87

## Summary

This PR modifies the PlatformIO project to enable all compiler warnings by setting the `-Wall` and `-Wextra` flags.

More information regarding PlatformIO build flags can be found here: https://docs.platformio.org/en/latest/projectconf/sections/env/options/build/build_flags.html.

More PRs will be sent to keep improving the code structure.

## Test it

Tested by compiling the source code.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
