### PR TITLE
Supports Arduino Nano by providing a new Arduino configuration.

### DIFF
--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -14,3 +14,10 @@ board = uno
 framework = arduino
 build_flags =
   -Wall -Wextra
+
+[env:nanoatmega328]
+platform = atmelavr
+board = nanoatmega328
+framework = arduino
+build_flags =
+  -Wall -Wextra

--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -8,16 +8,23 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:uno]
+; Base configuration for Atmel AVR based Arduino boards.
+[base_atmelavr]
 platform = atmelavr
-board = uno
 framework = arduino
+monitor_speed = 57600
+
+; Base configuration for build tools.
+[base_build]
 build_flags =
   -Wall -Wextra
 
+; Environment for Arduino Uno.
+[env:uno]
+extends = base_atmelavr, base_build
+board = uno
+
+; Environment for Arduino Nano.
 [env:nanoatmega328]
-platform = atmelavr
+extends = base_atmelavr, base_build
 board = nanoatmega328
-framework = arduino
-build_flags =
-  -Wall -Wextra


### PR DESCRIPTION
# 🎉 New feature

## Summary

The [README](https://github.com/Ekumen-OS/andino/blob/humble/andino_hardware/README.md#bill-of-materials) says that the main part is an Arduino Nano, but the Arduino Uno is configured instead. This PR adds the configuration for the Arduino Nano, so you can pick which development platform to use (tested with VSCode + PlatformIO).

## Test it

Pick the board, build and deploy the firmware using VSCode + PlatformIO.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
