### PR TITLE
Adds instructions to build a docker image in an x86/x64 architecture for arm64/v8

### DIFF
--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,0 +1,58 @@
+FROM arm64v8/ros:humble as base
+
+# Arguments for building
+ARG USERID
+ARG USER
+
+# Setup environment
+ENV TERM linux
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+# Copy requirement files and install dependencies
+COPY docker/requirements.txt .
+RUN apt-get update && apt-get install --no-install-recommends -y $(cat requirements.txt)
+RUN rm requirements.txt
+
+# Create a user with passwordless sudo
+RUN adduser --uid $USERID --gecos "ekumen developer" --disabled-password $USER
+RUN adduser $USER sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN echo "export QT_X11_NO_MITSHM=1" >> /home/$USER/.bashrc
+USER $USER
+
+# Adds USER to dialout and plugdev group.
+# This is needed to access the serial ports, for further references check
+# the libserial documentation.
+RUN sudo usermod -a -G dialout $USER
+RUN sudo usermod -a -G plugdev $USER
+
+# Creates the src folder of the workspace.
+RUN mkdir -p /home/$USER/ws/src
+
+# Adds to bashrc the ros humble overlay sourcing.
+RUN echo "source /opt/ros/humble/setup.bash" >> /home/$USER/.bashrc
+# Adds colcon autocomplete
+RUN echo "source /usr/share/colcon_argcomplete/hook/colcon-argcomplete.bash" >> /home/$USER/.bashrc
+
+# Updates and initializes rosdep.
+RUN sudo apt upgrade -y && sudo apt update && rosdep update
+
+# Defines a workspace folder.
+WORKDIR /home/$USER/ws
+
+CMD ["/bin/bash"]
+
+FROM base AS dev
+
+# Clone the repository.
+RUN git clone https://github.com/Ekumen-OS/andino.git src/
+# Install the workspace dependencies and the repository.
+# TODO: fix dependencies so rosdep does not fail.
+RUN rosdep install --from-paths src --ignore-src -i -y -r || true
+SHELL ["/bin/bash", "-c"]
+RUN source /opt/ros/humble/setup.bash && \
+    colcon build --event-handlers console_direct+ && \
+    colcon test --event-handlers console_direct+
+# Source the andino workspace.
+RUN echo "source /ws/install/setup.bash" >> /home/$USER/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -63,3 +63,92 @@ file the repositories in your workspace.
   ```sh
   colcon build
   ```
+### Building a docker image for the Raspberry PI
+
+This is convenient to avoid running the installation process in the Raspberry Pi, and to have a unified environment. The following will guide you to cross compile the docker image from an x86/x64 computing platform into an arm64 compatible image.
+
+#### Configure the `buildx` driver
+
+Run the following to see the `docker buildx` nodes:
+
+```
+$ docker buildx ls
+NAME/NODE            DRIVER/ENDPOINT             STATUS  BUILDKIT             PLATFORMS
+default              docker                                                   
+  default            default                     running v0.11.7+d3e6c1360f6e linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
+```
+
+As you can see, the `default` cannot build images for `linux/arm64/v8`. Those are required for running in the Raspberry Pi. You can create a node that works for that the following way:
+
+
+```
+docker buildx create --name andino_arm64_arch --platform "linux/arm64/v8" --driver "docker-container"
+```
+
+And select it then:
+
+```
+$ docker buildx use andino_arm64_arch
+$ docker buildx ls
+NAME/NODE            DRIVER/ENDPOINT             STATUS  BUILDKIT             PLATFORMS
+andino_arm64_arch *  docker-container                                         
+  andino_arm64_arch0 unix:///var/run/docker.sock running v0.12.4              linux/arm64*, linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
+default              docker                                                   
+  default            default                     running v0.11.7+d3e6c1360f6e linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/amd64/v4, linux/386
+```
+
+#### Build the arm64/v8 image
+
+At this point, the only required step is building the image:
+
+
+Run the following (known bug: https://github.com/multiarch/alpine/issues/32 ) so sudo can execute:
+
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+```
+and then:
+
+```
+docker buildx build -t andino:arm64 \
+  --platform linux/arm64/v8 \
+  --build-arg USERID=$(id -u) \
+  --build-arg USER=$(whoami) \
+  --load \
+  --file docker/Dockerfile.arm64 .
+```
+
+The previous command will create a docker image called `andino` and tag it with `arm64`.
+
+That's it! You have an andino docker image to run in your Raspberry Pi.
+
+#### Transfer it to the Raspberry Pi
+
+After a successful build, consider running the following to save to a tarball the docker image and copying it to the Raspberry Pi:
+
+```
+docker save andino:arm64 > andino_arm64.tar
+```
+
+You can copy it via `scp`:
+
+```
+scp andino_arm64.tar <andino_ip>@<andino_ip>:/tmp
+```
+
+And then load and execute the docker image there:
+
+```
+ssh <andino_ip>@<andino_ip>
+docker load < andino_arm64.tar
+docker run \
+  --rm \
+  --privileged \
+  --net=host \
+  -it \
+  -v /dev:/dev \
+  --name andino_container \
+  andino:arm64
+```
+
+As you can see, you will need docker installed in the Raspberry Pi, [here](https://docs.docker.com/engine/install/ubuntu/) are the installation docs.


### PR DESCRIPTION
# 🎉 New feature

Part of #200 

## Summary

Povides a dockerized container to run in arm64/v8.
This is by no means a definite solution, given that it is presented as a self-contained docker image which packs the current state of the repository, builds and tests it, which isn't great for development. It is not great for staged versions either given that we have a plethora of unnecessary dependencies and the port / driver configurations are not included in this image.

It should help to foster the [discussion](https://github.com/Ekumen-OS/andino/discussions/20) and #200 by providing a baseline that works.
 
## Test it

Followed the readme instructions in my laptop, connected the RPI to the camera, the lidar and the arduino uno. As a base system I had the system fully installed as the readme says, so all the port configuration was already there. After launching the container, I ran the following:

```
ros2 launch andino_bringup andino_robot.launch.py
```

I could see an error with the camera, different to #198 but probably related and just twisted because of the docker configuration. After setting the ROS_DOMAIN_ID, I could see with `rqt_gui` different topic information and similarly a partial visualization with RViz. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
