### PR TITLE
Rename Shell class init method

### DIFF
--- a/andino_firmware/src/app.cpp
+++ b/andino_firmware/src/app.cpp
@@ -130,7 +130,7 @@ void App::setup() {
   right_pid_controller_.reset(right_encoder_.read());
 
   // Initialize command shell.
-  shell_.init(Serial);
+  shell_.begin(Serial);
   shell_.set_default_callback(cmd_unknown_cb);
   shell_.register_command(Commands::kReadAnalogGpio, cmd_read_analog_gpio_cb);
   shell_.register_command(Commands::kReadDigitalGpio, cmd_read_digital_gpio_cb);

--- a/andino_firmware/src/shell.cpp
+++ b/andino_firmware/src/shell.cpp
@@ -33,7 +33,7 @@
 
 namespace andino {
 
-void Shell::init(Stream& stream) { stream_ = &stream; }
+void Shell::begin(Stream& stream) { stream_ = &stream; }
 
 void Shell::set_default_callback(CommandCallback callback) { default_callback_ = callback; }
 

--- a/andino_firmware/src/shell.h
+++ b/andino_firmware/src/shell.h
@@ -44,7 +44,7 @@ class Shell {
   /// @brief Initializes the shell.
   ///
   /// @param stream Data stream.
-  void init(Stream& stream);
+  void begin(Stream& stream);
 
   /// @brief Sets the default callback for unknown commands.
   ///


### PR DESCRIPTION
# 🎉 New feature

Related: #87

## Summary

This PR modifies the Shell class init method to `begin` from `init`, for consistency.

## Test it

Tested by running the following commands and ensuring code builds and tests build and pass:
```
pio run
```
and
```
pio test --environment=desktop
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
