### PR TITLE
Matches convention with cmd_vel and odom topics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,38 @@ By default sensors like the camera and the lidar are initialized. This can be di
 - include_rplidar: `true` as default.
 - include_camera: `true` as default.
 
-After the robot is launched, use `ROS 2 CLI` for inspecting environment. E.g: By doing `ros2 topic list` the available topics can be displayed.
+After the robot is launched, use `ROS 2 CLI` for inspecting environment.
+For example, by doing `ros2 topic list` the available topics can be displayed:
+
+    /camera_info
+    /cmd_vel
+    /image_raw
+    /odom
+    /robot_description
+    /scan
+    /tf
+    /tf_static
+
+   _Note: Showing just some of them_
 
 ### Teleoperation
 
 Launch files for using the keyboard or a joystick for teleoperating the robot are provided.
 
-[`twist_mux`](http://wiki.ros.org/twist_mux) is used to at the same time accept command velocities from different topics using certain priority for each one of them (See [twist_mux config](andino_bringup/config/twist_mux.yaml)). Available topics are (ordering by priority):
+#### Keyboard
 
-- cmd_vel
-- cmd_vel_keyboard
-- cmd_vel_joy
+```
+ros2 launch andino_bringup teleop_keyboard.launch.py
+```
+This is similarly to just call `ros2 run teleop_twist_keyboard teleop_twist_keyboard`
+
+#### Joystick
+
+Using a joystick for teleoperating is notably better.
+You need the joystick configured as explained [here](andino_hardware/README.md#Using-joystick-for-teleoperation).
+```
+ros2 launch andino_bringup teleop_joystick.launch.py
+```
 
 ### RViz
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Launch files for using the keyboard or a joystick for teleoperating the robot ar
 ```
 ros2 launch andino_bringup teleop_keyboard.launch.py
 ```
-This is similarly to just call `ros2 run teleop_twist_keyboard teleop_twist_keyboard`
+This is similarly to just executing `ros2 run teleop_twist_keyboard teleop_twist_keyboard`.
 
 #### Joystick
 

--- a/andino_bringup/launch/andino_robot.launch.py
+++ b/andino_bringup/launch/andino_robot.launch.py
@@ -103,14 +103,6 @@ def generate_launch_description():
     rplidar_timer = TimerAction(period=3.0, actions=[include_rplidar])
     camera_timer = TimerAction(period=3.0, actions=[include_camera])
 
-    twist_mux_params = os.path.join(pkg_andino_bringup,'config','twist_mux.yaml')
-    twist_mux = Node(
-            package="twist_mux",
-            executable="twist_mux",
-            parameters=[twist_mux_params],
-            remappings=[('/cmd_vel_out','/diff_controller/cmd_vel_unstamped')]
-        )
-
     return LaunchDescription([
         include_andino_description,
         andino_control_timer,
@@ -118,5 +110,4 @@ def generate_launch_description():
         camera_timer,
         rplidar_arg,
         rplidar_timer,
-        twist_mux,
     ])

--- a/andino_bringup/launch/teleop_joystick.launch.py
+++ b/andino_bringup/launch/teleop_joystick.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
 
     cmd_vel_topic_arg = DeclareLaunchArgument(
             'cmd_vel_topic',
-            default_value='/cmd_vel_joy',
+            default_value='/cmd_vel',
             description='Indicates the cmd_vel topic.')
     cmd_vel_topic =  LaunchConfiguration('cmd_vel_topic')
 

--- a/andino_bringup/launch/teleop_keyboard.launch.py
+++ b/andino_bringup/launch/teleop_keyboard.launch.py
@@ -36,7 +36,6 @@ def generate_launch_description():
             package='teleop_twist_keyboard',
             executable='teleop_twist_keyboard',
             name='teleop_twist_keyboard_node',
-            remappings=[('/cmd_vel','/cmd_vel_keyboard')],
             output='screen',
             prefix = 'xterm -e',
          )

--- a/andino_bringup/package.xml
+++ b/andino_bringup/package.xml
@@ -17,7 +17,6 @@
   <exec_depend>rplidar_ros</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>joy_linux</exec_depend>
-  <exec_depend>twist_mux</exec_depend>
   <exec_depend>v4l2_camera</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>rosbag2_storage_mcap</exec_depend>

--- a/andino_control/README.md
+++ b/andino_control/README.md
@@ -23,8 +23,8 @@ flowchart TD
     M(Controller Manager) -..-> |manages lifecycle| C
     M(Controller Manager) -..-> |activates hw component| B
 
-    D["/diff_controller/cmd_vel"] -->|subs| A
-    A -->|pubs| O["/diff_controller/odom"]
+    D["/cmd_vel"] -->|subs| A
+    A -->|pubs| O["/odom"]
     A -->|pubs| T["/tf"]
     C -->|pubs| J["/joint_states"]
 

--- a/andino_control/config/andino_controllers.yaml
+++ b/andino_control/config/andino_controllers.yaml
@@ -10,6 +10,7 @@ controller_manager:
 
 diff_controller:
   ros__parameters:
+    # See https://github.com/ros-controls/ros2_controllers/blob/humble/diff_drive_controller/src/diff_drive_controller_parameter.yaml
     publish_rate: 50.0
     left_wheel_names: ['left_wheel_joint']
     right_wheel_names: ['right_wheel_joint']

--- a/andino_control/launch/andino_control.launch.py
+++ b/andino_control/launch/andino_control.launch.py
@@ -54,7 +54,12 @@ def generate_launch_description():
         executable="ros2_control_node",
         parameters=[{'robot_description': ParameterValue(robot_description, value_type=str)},
                     controller_params_file],
-
+        remappings=[
+            ('/diff_controller/cmd_vel', '/cmd_vel'), # Used use_stamped_vel param is true
+            ('/diff_controller/cmd_vel_unstamped', '/cmd_vel'), # Used if use_stamped_vel param is false
+            ('/diff_controller/cmd_vel_out', '/cmd_vel_out'), # Used if publish_limited_velocity param is true
+            ('/diff_controller/odom', '/odom'),
+        ],
         output="both",
     )
 

--- a/andino_control/launch/andino_control.launch.py
+++ b/andino_control/launch/andino_control.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
         parameters=[{'robot_description': ParameterValue(robot_description, value_type=str)},
                     controller_params_file],
         remappings=[
-            ('/diff_controller/cmd_vel', '/cmd_vel'), # Used use_stamped_vel param is true
+            ('/diff_controller/cmd_vel', '/cmd_vel'), # Used if use_stamped_vel param is true
             ('/diff_controller/cmd_vel_unstamped', '/cmd_vel'), # Used if use_stamped_vel param is false
             ('/diff_controller/cmd_vel_out', '/cmd_vel_out'), # Used if publish_limited_velocity param is true
             ('/diff_controller/odom', '/odom'),


### PR DESCRIPTION
# 🎉 New feature

Related to #190 

## Summary
Matches cmd_vel and odom convention on topics. This enhances easier integration with other layers/technologies.

 - Adds remapping to `controller_manager`'s `diff_controller` node.
   - `diff_controller/odom` -> `odom`
   - `diff_controller/cmd_vel_unstamped` -> `cmd_vel`
 - Removes dependency on twist mux
   
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)