### PR TITLE
Add missing dependency for keyboard teleop launchfile

### DIFF
--- a/andino_bringup/package.xml
+++ b/andino_bringup/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>v4l2_camera</exec_depend>
   <exec_depend>laser_filters</exec_depend>
   <exec_depend>rosbag2_storage_mcap</exec_depend>
+  <exec_depend>xterm</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #226

## Summary
The `andino_bringup` package uses the `xterm` command when launching the keyboard teleop launchfile, but that dependency doesn't exist on the `package.xml` file.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.