### PR TITLE
Fixed wheel diameter in URDF

### DIFF
--- a/andino_gz_classic/urdf/andino_gz_classic.xacro
+++ b/andino_gz_classic/urdf/andino_gz_classic.xacro
@@ -67,7 +67,7 @@
 
       <!-- kinematics -->
       <wheel_separation>0.137</wheel_separation>
-      <wheel_diameter>0.035</wheel_diameter>
+      <wheel_diameter>0.0662</wheel_diameter>
 
       <!-- limits -->
       <max_wheel_torque>20</max_wheel_torque>


### PR DESCRIPTION
This is just a test pull request to start getting used to the workflow, just changed the value of the wheel diameter to be coherent with the wheel radius in the YAML.

I have reviewed other modules and there is n sense in loading the YAML into the URDF because none of the paramters in it are used in this xacro file, so regarding that this is the only place the wheel_diameter is used it would not be bad to hardcode it.
