### PR TITLE
Simplify argument for rsp

### DIFF
--- a/andino_bringup/launch/andino_robot.launch.py
+++ b/andino_bringup/launch/andino_robot.launch.py
@@ -61,9 +61,6 @@ def generate_launch_description():
         PythonLaunchDescriptionSource(
             os.path.join(pkg_andino_description, 'launch', 'andino_description.launch.py'),
         ),
-        launch_arguments={
-            'rsp': 'True',
-        }.items()
     )
 
     # Include andino_control launch file

--- a/andino_description/launch/andino_description.launch.py
+++ b/andino_description/launch/andino_description.launch.py
@@ -29,42 +29,41 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-
-from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescription, LaunchContext
-from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import Node
-
 import xacro
 
-def generate_launch_description():
+from ament_index_python.packages import get_package_share_directory
 
-    # Arguments
-    rsp_argument = DeclareLaunchArgument('rsp', default_value='true',
-                          description='Run robot state publisher node.')
+from launch_ros.actions import Node
+from launch import LaunchDescription
+
+
+def generate_launch_description():
 
     # Obtains andino_description's share directory path.
     pkg_andino_description = get_package_share_directory('andino_description')
 
     # Obtain urdf from xacro files.
-    arguments = {'yaml_config_dir': os.path.join(pkg_andino_description, 'config', 'andino')}
-    doc = xacro.process_file(os.path.join(pkg_andino_description, 'urdf', 'andino.urdf.xacro'), mappings = arguments)
+    arguments = {
+        'yaml_config_dir': os.path.join(pkg_andino_description, 'config', 'andino')
+    }
+    doc = xacro.process_file(
+        os.path.join(pkg_andino_description, 'urdf', 'andino.urdf.xacro'),
+        mappings=arguments,
+    )
     robot_desc = doc.toprettyxml(indent='  ')
-    params = {'robot_description': robot_desc,
-              'publish_frequency': 30.0}
+    params = {'robot_description': robot_desc, 'publish_frequency': 30.0}
 
     # Robot state publisher
-    rsp = Node(package='robot_state_publisher',
-                executable='robot_state_publisher',
-                namespace='',
-                output='both',
-                parameters=[params],
-                condition=IfCondition(LaunchConfiguration('rsp'))
+    rsp = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        namespace='',
+        output='both',
+        parameters=[params],
     )
 
-    return LaunchDescription([
-        rsp_argument,
-        rsp,
-    ])
+    return LaunchDescription(
+        [
+            rsp,
+        ]
+    )

--- a/andino_description/launch/view_andino.launch.py
+++ b/andino_description/launch/view_andino.launch.py
@@ -31,41 +31,37 @@
 import os
 
 from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import Node
 
-import xacro
+from launch_ros.actions import Node
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
 
 def generate_launch_description():
 
     # Arguments
-    rviz_argument = DeclareLaunchArgument('rviz', default_value='true',
-                          description='Open RViz.')
-    rsp_argument = DeclareLaunchArgument('rsp', default_value='true',
-                          description='Run robot state publisher node.')
-    jsp_argument = DeclareLaunchArgument('jsp', default_value='true',
-                          description='Run joint state publisher node.')
+    rviz_argument = DeclareLaunchArgument(
+        'rviz', default_value='true', description='Open RViz.'
+    )
+    rsp_argument = DeclareLaunchArgument(
+        'rsp', default_value='true', description='Run robot state publisher node.'
+    )
+    jsp_argument = DeclareLaunchArgument(
+        'jsp', default_value='true', description='Run joint state publisher node.'
+    )
 
     # Obtains andino_description's share directory path.
     pkg_andino_description = get_package_share_directory('andino_description')
-
-    # Obtain urdf from xacro files.
-    arguments = {'yaml_config_dir': os.path.join(pkg_andino_description, 'config', 'andino')}
-    doc = xacro.process_file(os.path.join(pkg_andino_description, 'urdf', 'andino.urdf.xacro'), mappings = arguments)
-    robot_desc = doc.toprettyxml(indent='  ')
-    params = {'robot_description': robot_desc,
-              'publish_frequency': 30.0}
-
-    # Robot state publisher
-    rsp = Node(package='robot_state_publisher',
-                executable='robot_state_publisher',
-                namespace='',
-                output='both',
-                parameters=[params],
-                condition=IfCondition(LaunchConfiguration('rsp'))
+    rsp = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                pkg_andino_description, 'launch', 'andino_description.launch.py'
+            ),
+        ),
+        condition=IfCondition(LaunchConfiguration('rsp')),
     )
 
     # Joint state publisher gui
@@ -74,22 +70,27 @@ def generate_launch_description():
         executable='joint_state_publisher_gui',
         namespace='',
         name='joint_state_publisher_gui',
-        condition=IfCondition(LaunchConfiguration('jsp'))
+        condition=IfCondition(LaunchConfiguration('jsp')),
     )
 
     # RViz
     rviz = Node(
         package='rviz2',
         executable='rviz2',
-        arguments=['-d', os.path.join(pkg_andino_description, 'rviz', 'andino_description.rviz')],
-        condition=IfCondition(LaunchConfiguration('rviz'))
+        arguments=[
+            '-d',
+            os.path.join(pkg_andino_description, 'rviz', 'andino_description.rviz'),
+        ],
+        condition=IfCondition(LaunchConfiguration('rviz')),
     )
 
-    return LaunchDescription([
-        jsp_argument,
-        rviz_argument,
-        rsp_argument,
-        jsp_gui,
-        rviz,
-        rsp,
-    ])
+    return LaunchDescription(
+        [
+            jsp_argument,
+            rviz_argument,
+            rsp_argument,
+            jsp_gui,
+            rviz,
+            rsp,
+        ]
+    )


### PR DESCRIPTION
# 🎉 New feature


## Summary
Simplify arguments for the robot software publisher node. The robot description node needs to run always and was already hardcoded to True. Also reuse the andino_description.launch.py in the view_andino.launch.py launchfile. Lastly, ran `black --skip-string-normalization` against these 2 launchfile to fix some linting issues.

## Test it
- `ros2 launch andino_description andino_description.launch.py`
- `ros2 launch andino_description view_andino.launch.py`

These commands should work like they did before.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
