### PR TITLE
Relay stamped cmd vel

### DIFF
--- a/andino_bringup/config/joystick.yaml
+++ b/andino_bringup/config/joystick.yaml
@@ -25,3 +25,4 @@ teleop_node:
     enable_turbo_button: 5
 
     require_enable_button: true
+    publish_stamped_twist: true

--- a/andino_bringup/launch/teleop_joystick.launch.py
+++ b/andino_bringup/launch/teleop_joystick.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
 
     cmd_vel_topic_arg = DeclareLaunchArgument(
             'cmd_vel_topic',
-            default_value='/cmd_vel',
+            default_value='/cmd_vel_stamped',
             description='Indicates the cmd_vel topic.')
     cmd_vel_topic =  LaunchConfiguration('cmd_vel_topic')
 

--- a/andino_bringup/launch/teleop_keyboard.launch.py
+++ b/andino_bringup/launch/teleop_keyboard.launch.py
@@ -29,7 +29,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from launch import LaunchDescription
+
 from launch_ros.actions import Node
+
 
 def generate_launch_description():
     teleop_node = Node(
@@ -38,6 +40,8 @@ def generate_launch_description():
             name='teleop_twist_keyboard_node',
             output='screen',
             prefix = 'xterm -e',
+            parameters=[{'stamped': True}],
+            remappings=[('/cmd_vel', 'cmd_vel_stamped')],
          )
 
     return LaunchDescription([

--- a/andino_control/launch/andino_control.launch.py
+++ b/andino_control/launch/andino_control.launch.py
@@ -55,10 +55,9 @@ def generate_launch_description():
         parameters=[{'robot_description': ParameterValue(robot_description, value_type=str)},
                     controller_params_file],
         remappings=[
-            ('/diff_controller/cmd_vel', '/cmd_vel'), # Used if use_stamped_vel param is true
-            ('/diff_controller/cmd_vel_unstamped', '/cmd_vel'), # Used if use_stamped_vel param is false
-            ('/diff_controller/cmd_vel_out', '/cmd_vel_out'), # Used if publish_limited_velocity param is true
-            ('/diff_controller/odom', '/odom'),
+            ('/diff_controller/cmd_vel', 'cmd_vel_stamped'),
+            ('/diff_controller/cmd_vel_out', 'cmd_vel_out'),
+            ('/diff_controller/odom', 'odom'),
         ],
         output="both",
     )
@@ -83,10 +82,18 @@ def generate_launch_description():
         )
     )
 
+    relay_node = Node(
+        package="topic_tools",
+        executable="relay_field",
+        name="cmd_vel_relay",
+        arguments=["cmd_vel", "cmd_vel_stamped", "geometry_msgs/TwistStamped", "{header: {stamp: {sec: 0, nanosec: 0}, frame_id: ''}, twist: m}", "--wait-for-start"],
+    )
+
     nodes = [
         control_node,
         joint_state_broadcaster_spawner,
         delay_diff_drive_controller_spawner_after_joint_state_broadcaster_spawner,
+        relay_node,
     ]
 
     return LaunchDescription(nodes)

--- a/andino_control/package.xml
+++ b/andino_control/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #281

## Summary
This remaps the diff_drive controller velocity command input to `/cmd_vel_stamped` and adds a relay node that transforms any message received in the `/cmd_vel` topic (unstamped) and stamps a header to it and republishes to `/cmd_vel_stamped`. This also changes the keyboard and joystick teleop nodes to use stamped messages and send them directly to the `/cmd_vel_stamped` topic

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.