### PR TITLE
refactor[andino_bringup]: add joystick and keyboard config files for …

### DIFF
--- a/andino_bringup/config/joystick.yaml
+++ b/andino_bringup/config/joystick.yaml
@@ -1,6 +1,9 @@
 joy_linux_node:
   ros__parameters:
-    device_id: 0
+    # dev: /dev/input/js2 <---- Use this if you have more than one joystick and want to specify which one to use.
+    # For example:
+    # - Nintendo Switch with Ubuntu: dev: /dev/input/js2
+    dev: 0
     deadzone: 0.05
     autorepeat_rate: 20.0
 
@@ -8,20 +11,23 @@ teleop_node:
   ros__parameters:
     axis_linear:
       x: 1
+      y: 3 
     scale_linear:
-      x: 0.5
+      x: 0.3
+      y: 0.3
     scale_linear_turbo:
       x: 1.0
+      y: 1.0
 
     axis_angular:
-      yaw: 3
+      yaw: 0
     scale_angular:
-      yaw: 1.0
+      yaw: 4.0
     scale_angular_turbo:
-      yaw: 2.0
+      yaw: 10.0
 
 
-    enable_button: 4
+    enable_button: 7
     enable_turbo_button: 5
 
     require_enable_button: true

--- a/andino_bringup/config/keyboard.yaml
+++ b/andino_bringup/config/keyboard.yaml
@@ -1,0 +1,4 @@
+teleop_twist_keyboard_node:
+  ros__parameters:
+    speed: 0.3
+    turn: 4.0

--- a/andino_bringup/launch/camera.launch.py
+++ b/andino_bringup/launch/camera.launch.py
@@ -56,6 +56,8 @@ def generate_launch_description():
                 'image_size': [640, 480],
                 'camera_frame_id': 'camera_link',
                 'camera_info_url': LaunchConfiguration('intrinsic_params_file'),
+                'vertical_flip': False,
+                'horizontal_flip': False,
             }],
         )
     ])

--- a/andino_bringup/launch/teleop_joystick.launch.py
+++ b/andino_bringup/launch/teleop_joystick.launch.py
@@ -49,6 +49,7 @@ def generate_launch_description():
     joy_linux_node = Node(
             package='joy_linux',
             executable='joy_linux_node',
+            name='joy_linux_node',
             parameters=[joystick_config],
          )
 
@@ -57,7 +58,7 @@ def generate_launch_description():
             executable='teleop_node',
             name='teleop_node',
             parameters=[joystick_config],
-            remappings=[('/cmd_vel', cmd_vel_topic)]
+            remappings=[('cmd_vel', cmd_vel_topic)]
          )
 
     return LaunchDescription([

--- a/andino_bringup/launch/teleop_keyboard.launch.py
+++ b/andino_bringup/launch/teleop_keyboard.launch.py
@@ -28,6 +28,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
+
+from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition, UnlessCondition
@@ -37,6 +40,8 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    keyboard_config = os.path.join(get_package_share_directory('andino_bringup'),'config','keyboard.yaml')
+    
     stamped_arg = DeclareLaunchArgument(
         'stamped',
         default_value='true',
@@ -51,7 +56,7 @@ def generate_launch_description():
             name='teleop_twist_keyboard_node',
             output='screen',
             prefix='xterm -e',
-            parameters=[{'stamped': True}],
+            parameters=[{'stamped': True}, keyboard_config],
             remappings=[('/cmd_vel', 'cmd_vel_stamped')],
             condition=IfCondition(stamped),
          )
@@ -62,7 +67,7 @@ def generate_launch_description():
             name='teleop_twist_keyboard_node',
             output='screen',
             prefix='xterm -e',
-            parameters=[{'stamped': False}],
+            parameters=[{'stamped': False}, keyboard_config],
             remappings=[('/cmd_vel', 'cmd_vel')],
             condition=UnlessCondition(stamped),
          )


### PR DESCRIPTION
# 🎉 New feature

Closes #312 

## Summary
I add the yaml files and this ones are being used on the corresponding launch files

## Test it
Launch files for using the keyboard or a joystick for teleoperating the robot are provided.

Keyboard
```Bash
ros2 launch andino_bringup teleop_keyboard.launch.py
```

This is similarly to just executing ros2 run teleop_twist_keyboard teleop_twist_keyboard.

Joystick
Using a joystick for teleoperating is notably better. You need the joystick configured as explained [here](https://file+.vscode-resource.vscode-cdn.net/home/santiagoek/ekumen/andino/andino_hardware/README.md#Using-joystick-for-teleoperation).
```Bash
ros2 launch andino_bringup teleop_joystick.launch.py
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
