### PR TITLE
Fix deprecated on_init signature for ROS 2 Jazzy

### DIFF
--- a/andino_base/include/andino_base/diffdrive_andino.h
+++ b/andino_base/include/andino_base/diffdrive_andino.h
@@ -53,7 +53,8 @@ class DiffDriveAndino : public hardware_interface::SystemInterface {
   /// @brief Default constructor for the DiffDriveAndino class.
   DiffDriveAndino() = default;
 
-  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+  hardware_interface::CallbackReturn on_init(
+      const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
   hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
 

--- a/andino_base/src/diffdrive_andino.cpp
+++ b/andino_base/src/diffdrive_andino.cpp
@@ -34,8 +34,9 @@
 
 namespace andino_base {
 
-hardware_interface::CallbackReturn DiffDriveAndino::on_init(const hardware_interface::HardwareInfo& info) {
-  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS) {
+hardware_interface::CallbackReturn DiffDriveAndino::on_init(
+    const hardware_interface::HardwareComponentInterfaceParams& params) {
+  if (hardware_interface::SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS) {
     return hardware_interface::CallbackReturn::ERROR;
   }
 
@@ -58,7 +59,7 @@ hardware_interface::CallbackReturn DiffDriveAndino::on_init(const hardware_inter
                (kEncTicksPerRevParam + static_cast<std::string>(": ") + info_.hardware_parameters[kEncTicksPerRevParam])
                    .c_str());
 
-  for (const hardware_interface::ComponentInfo& joint : info.joints) {
+  for (const hardware_interface::ComponentInfo& joint : info_.joints) {
     // DiffDriveAndino has exactly two states and one command interface on each joint
     if (joint.command_interfaces.size() != 1) {
       RCLCPP_FATAL(logger_, "Joint '%s' has %zu command interfaces found. 1 expected.", joint.name.c_str(),


### PR DESCRIPTION
Update DiffDriveAndino::on_init to use HardwareComponentInterfaceParams instead of HardwareInfo, which is deprecated in ROS 2 Jazzy, eliminating the related compilation warning.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://github.com/Ekumen-OS/andino/blob/humble/CONTRIBUTING.md
-->

# 🦟 Bug fix

Fixes #N/A

## Summary
`DiffDriveAndino::on_init` was using the deprecated `hardware_interface::HardwareInfo`
parameter signature, causing a compilation warning in ROS 2 Jazzy.

This PR updates the signature to use `hardware_interface::HardwareComponentInterfaceParams`
as required by the current `ros2_control` API, eliminating the deprecation warning.

**Before:** compiles with deprecation warning on ROS 2 Jazzy
**After:** compiles cleanly with no warnings

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

