### PR TITLE
[andino_firmware] Add Docker development environment

### DIFF
--- a/andino_firmware/docker/Dockerfile
+++ b/andino_firmware/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.11-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    gcc \
+    g++ \
+    make \
+    git \
+    curl \
+    udev \
+    libusb-1.0-0 \
+    libusb-1.0-0-dev \
+    usbutils \
+    doxygen \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PlatformIO and gcovr.
+RUN pip install --no-cache-dir -U platformio gcovr
+
+# Pre-create the PlatformIO cache directory with open permissions so that the
+# named volume mounted here is writable by any host UID/GID at runtime.
+RUN mkdir -p /tmp/.platformio && chmod 777 /tmp/.platformio
+
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/andino_firmware/docker/README.md
+++ b/andino_firmware/docker/README.md
@@ -1,0 +1,75 @@
+# Docker Development Environment
+
+This directory contains the Docker and Docker Compose environment configured for developing, compiling, testing, and flashing the Andino firmware.
+
+The Docker environment pre-installs Python 3, GCC, G++, Make, PlatformIO Core, and essential USB tools (udev, libusb) to make firmware development seamless without needing to install anything on your host machine except Docker.
+
+---
+
+## Directory Layout
+
+- **`Dockerfile`**: Reusable environment container image definition.
+- **`compose.yaml`**: Docker Compose configuration referencing `Dockerfile` and setting up volume mappings and USB passthrough.
+
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+---
+
+## Quick Start
+
+Execute these commands from the **andino_firmware** directory:
+
+### 1. Build the Docker Image
+To build the development environment image:
+```bash
+docker compose -f docker/compose.yaml build
+```
+
+### 2. Compile the Firmware
+To build the firmware target `Arduino Uno` inside the container:
+```bash
+docker compose -f docker/compose.yaml run --rm dev pio run -e uno
+```
+
+To build the firmware target `Arduino Nano` inside the container:
+```bash
+docker compose -f docker/compose.yaml run --rm dev pio run -e nanoatmega328
+```
+
+### 3. Run Native Unit Tests
+To compile and execute the native unit tests:
+```bash
+docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
+```
+
+### 4. Flash the Microcontroller (USB Passthrough)
+
+The Docker Compose configuration is set up with:
+- `privileged: true`
+- `/dev:/dev` mount
+- `network_mode: host`
+
+This allows the container full access to USB devices connected to the host machine. 
+
+To upload/flash your firmware to the Arduino board:
+
+Connect it to your host machine's USB port, then run the upload command from the root of the repository:
+```bash
+# Arduino Uno
+docker compose -f docker/compose.yaml run --rm dev pio run -e uno --target upload
+
+# Arduino Nano
+docker compose -f docker/compose.yaml run --rm dev pio run -e nanoatmega328 --target upload
+```
+
+### 5. Interactive Shell
+To launch an interactive bash shell inside the development container:
+```bash
+docker compose -f docker/compose.yaml run --rm dev
+```
+From here you can execute any `pio` commands, run linting tools, or inspect files.

--- a/andino_firmware/docker/compose.yaml
+++ b/andino_firmware/docker/compose.yaml
@@ -1,0 +1,33 @@
+name: andino-firmware
+
+services:
+  dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: andino-firmware-dev:latest
+    container_name: andino_firmware_dev
+    # Run container as the host's UID and GID to ensure proper ownership of any created files.
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      # Mount the andino_firmware directory into the workspace directory.
+      - ..:/workspace
+      # Persist the PlatformIO package and platform cache under a user-writable path.
+      - pio_cache:/tmp/.platformio
+      # Pass through USB devices and system events for firmware flashing.
+      - /dev:/dev
+    environment:
+      # Direct PlatformIO to use the persistent volume for its core directory.
+      - PLATFORMIO_CORE_DIR=/tmp/.platformio
+    # Run container in privileged mode to enable USB hardware access.
+    privileged: true
+    # Use host network to simplify any networking or debugging if needed.
+    network_mode: host
+    # Keep the container running in the background for interactive use.
+    tty: true
+    stdin_open: true
+    working_dir: /workspace
+
+volumes:
+  pio_cache:
+    name: andino_firmware_pio_cache


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR adds a Docker-based development environment for building, testing, and flashing the andino_firmware, providing a reproducible and host-independent alternative to a manual PlatformIO installation.

## Test it
    
Build the image (from `andino_firmware/`):

```
docker compose -f docker/compose.yaml build
```

Compile for Arduino Uno:

```
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
```

Compile for Arduino Nano:

```
docker compose -f docker/compose.yaml run --rm dev pio run -e nanoatmega328
```

Run unit tests:

```
docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
```

Start an interactive shell:

```
docker compose -f docker/compose.yaml run --rm dev
```

## Checklist
  - [X] Signed all commits for DCO
  - [ ] Added tests
  - [X] Added example and/or tutorial
  - [X] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.