### PR TITLE
[andino_firmware] Decouple HAL interfaces from physical pin members

### DIFF
--- a/andino_firmware/include/andino/bsp/digital_out_arduino.h
+++ b/andino_firmware/include/andino/bsp/digital_out_arduino.h
@@ -39,11 +39,15 @@ class DigitalOutArduino : public DigitalOut {
   /// @brief Constructs a DigitalOutArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit DigitalOutArduino(const int gpio_pin) : DigitalOut(gpio_pin) {}
+  explicit DigitalOutArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {}
 
   void begin() const override;
 
   void write(int value) const override;
+
+ private:
+  /// GPIO pin.
+  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/bsp/interrupt_in_arduino.h
+++ b/andino_firmware/include/andino/bsp/interrupt_in_arduino.h
@@ -39,13 +39,17 @@ class InterruptInArduino : public InterruptIn {
   /// @brief Constructs a InterruptInArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit InterruptInArduino(const int gpio_pin) : InterruptIn(gpio_pin) {}
+  explicit InterruptInArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {}
 
   void begin() const override;
 
   int read() const override;
 
   void attach(InterruptCallback callback) const override;
+
+ private:
+  /// GPIO pin.
+  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/bsp/pwm_out_arduino.h
+++ b/andino_firmware/include/andino/bsp/pwm_out_arduino.h
@@ -39,11 +39,15 @@ class PwmOutArduino : public PwmOut {
   /// @brief Constructs a PwmOutArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit PwmOutArduino(const int gpio_pin) : PwmOut(gpio_pin) {}
+  explicit PwmOutArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {}
 
   void begin() const override;
 
   void write(int value) const override;
+
+ private:
+  /// GPIO pin.
+  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/hal/digital_in.h
+++ b/andino_firmware/include/andino/hal/digital_in.h
@@ -34,11 +34,6 @@ namespace andino {
 /// @brief This class defines an interface for digital inputs.
 class DigitalIn {
  public:
-  /// @brief Constructs a DigitalIn using the specified GPIO pin.
-  ///
-  /// @param gpio_pin GPIO pin.
-  explicit DigitalIn(const int gpio_pin) : gpio_pin_(gpio_pin) {}
-
   /// @brief Destructs the digital input.
   virtual ~DigitalIn() = default;
 
@@ -49,10 +44,6 @@ class DigitalIn {
   ///
   /// @return Digital input value.
   virtual int read() const = 0;
-
- protected:
-  /// GPIO pin.
-  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/hal/digital_out.h
+++ b/andino_firmware/include/andino/hal/digital_out.h
@@ -34,11 +34,6 @@ namespace andino {
 /// @brief This class defines an interface for digital outputs.
 class DigitalOut {
  public:
-  /// @brief Constructs a DigitalOut using the specified GPIO pin.
-  ///
-  /// @param gpio_pin GPIO pin.
-  explicit DigitalOut(const int gpio_pin) : gpio_pin_(gpio_pin) {}
-
   /// @brief Destructs the digital output.
   virtual ~DigitalOut() = default;
 
@@ -49,10 +44,6 @@ class DigitalOut {
   ///
   /// @param value Digital output value.
   virtual void write(int value) const = 0;
-
- protected:
-  /// GPIO pin.
-  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/hal/interrupt_in.h
+++ b/andino_firmware/include/andino/hal/interrupt_in.h
@@ -39,11 +39,6 @@ class InterruptIn : public DigitalIn {
   /// @brief Interrupt callback type.
   typedef void (*InterruptCallback)();
 
-  /// @brief Constructs a InterruptIn using the specified GPIO pin.
-  ///
-  /// @param gpio_pin GPIO pin.
-  explicit InterruptIn(const int gpio_pin) : DigitalIn(gpio_pin) {}
-
   /// @brief Destructs the digital interrupt input.
   virtual ~InterruptIn() = default;
 

--- a/andino_firmware/include/andino/hal/pwm_out.h
+++ b/andino_firmware/include/andino/hal/pwm_out.h
@@ -34,11 +34,6 @@ namespace andino {
 /// @brief This class defines an interface for PWM outputs.
 class PwmOut {
  public:
-  /// @brief Constructs a PwmOut using the specified GPIO pin.
-  ///
-  /// @param gpio_pin GPIO pin.
-  explicit PwmOut(const int gpio_pin) : gpio_pin_(gpio_pin) {}
-
   /// @brief Destructs the PWM output.
   virtual ~PwmOut() {}
 
@@ -50,10 +45,6 @@ class PwmOut {
   /// @param value PWM value.
   // TODO(jballoffet): Change this API to expect values from 0 to 100 (%).
   virtual void write(int value) const = 0;
-
- protected:
-  /// GPIO pin.
-  const int gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/test/drivers/test_encoder/encoder_test.cpp
+++ b/andino_firmware/test/drivers/test_encoder/encoder_test.cpp
@@ -43,7 +43,7 @@ using ::testing::Return;
 
 class MockInterruptIn : public andino::InterruptIn {
  public:
-  MockInterruptIn(const int gpio_pin) : andino::InterruptIn(gpio_pin) {}
+  MockInterruptIn() = default;
   MOCK_METHOD(void, begin, (), (const, override));
   MOCK_METHOD(int, read, (), (const, override));
   MOCK_METHOD(void, attach, (andino::InterruptIn::InterruptCallback callback), (const, override));
@@ -51,8 +51,8 @@ class MockInterruptIn : public andino::InterruptIn {
 
 class EncoderTest : public testing::Test {
  protected:
-  MockInterruptIn channel_a_interrupt_in_{0};
-  MockInterruptIn channel_b_interrupt_in_{0};
+  MockInterruptIn channel_a_interrupt_in_;
+  MockInterruptIn channel_b_interrupt_in_;
   andino::Encoder encoder_{&channel_a_interrupt_in_, &channel_b_interrupt_in_};
 };
 

--- a/andino_firmware/test/drivers/test_motor/motor_test.cpp
+++ b/andino_firmware/test/drivers/test_motor/motor_test.cpp
@@ -41,23 +41,23 @@ namespace {
 
 class MockDigitalOut : public andino::DigitalOut {
  public:
-  MockDigitalOut(const int gpio_pin) : andino::DigitalOut(gpio_pin) {}
+  MockDigitalOut() = default;
   MOCK_METHOD(void, begin, (), (const, override));
   MOCK_METHOD(void, write, (int value), (const, override));
 };
 
 class MockPwmOut : public andino::PwmOut {
  public:
-  MockPwmOut(const int gpio_pin) : andino::PwmOut(gpio_pin) {}
+  MockPwmOut() = default;
   MOCK_METHOD(void, begin, (), (const, override));
   MOCK_METHOD(void, write, (int value), (const, override));
 };
 
 class MotorTest : public testing::Test {
  protected:
-  MockDigitalOut enable_digital_out_{0};
-  MockPwmOut forward_pwm_out_{0};
-  MockPwmOut backward_pwm_out_{0};
+  MockDigitalOut enable_digital_out_;
+  MockPwmOut forward_pwm_out_;
+  MockPwmOut backward_pwm_out_;
 };
 
 TEST_F(MotorTest, Initialize) {


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR purifies the Hardware Abstraction Layer (HAL) interfaces inside the andino_firmware project. Previously, the base HAL interfaces (DigitalIn, DigitalOut, InterruptIn, and PwmOut) stored and required a physical gpio_pin parameter inside their constructors. This created a "leaky abstraction" that coupled high-level definitions directly to single-pin-based microcontrollers, forcing mock objects and future virtual/serial-based drivers to supply placeholder pin numbers.

## Test it

Build the image (if not already built):
```bash
docker compose -f docker/compose.yaml build
```

Run unit tests (all 27 tests should pass):
```bash
docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
```

Compile the firmware to verify no build regressions:
```bash
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.