### PR TITLE
[andino_firmware] Add Clock HAL and Arduino implementation

### DIFF
--- a/andino_firmware/include/andino/app/app.h
+++ b/andino_firmware/include/andino/app/app.h
@@ -38,6 +38,7 @@
 #include "andino/app/pid.h"
 #include "andino/bsp/pwm_out_arduino.h"
 #include "andino/bsp/serial_stream_arduino.h"
+#include "andino/bsp/clock_arduino.h"
 #include "andino/app/shell.h"
 
 namespace andino {
@@ -93,6 +94,9 @@ class App {
 
   /// Serial stream.
   static SerialStreamArduino serial_stream_;
+
+  /// System clock.
+  static ClockArduino clock_;
 
   /// Application command shell.
   static Shell shell_;

--- a/andino_firmware/include/andino/bsp/clock_arduino.h
+++ b/andino_firmware/include/andino/bsp/clock_arduino.h
@@ -1,0 +1,44 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "andino/hal/clock.h"
+
+namespace andino {
+
+/// @brief This class provides an Arduino implementation of the clock interface.
+class ClockArduino : public Clock {
+ public:
+  unsigned long millis() const override;
+
+  void delay(unsigned long ms) const override;
+};
+
+}  // namespace andino

--- a/andino_firmware/include/andino/hal/clock.h
+++ b/andino_firmware/include/andino/hal/clock.h
@@ -1,0 +1,51 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+namespace andino {
+
+/// @brief This class defines an interface for time measurement and control.
+class Clock {
+ public:
+  /// @brief Destructs the Clock object.
+  virtual ~Clock() = default;
+
+  /// @brief Gets the current time in milliseconds.
+  ///
+  /// @return Number of milliseconds since the device started.
+  virtual unsigned long millis() const = 0;
+
+  /// @brief Delays execution for a specified duration.
+  ///
+  /// @param ms Duration in milliseconds.
+  virtual void delay(unsigned long ms) const = 0;
+};
+
+}  // namespace andino

--- a/andino_firmware/src/app/app.cpp
+++ b/andino_firmware/src/app/app.cpp
@@ -86,6 +86,8 @@ namespace andino {
 
 SerialStreamArduino App::serial_stream_;
 
+ClockArduino App::clock_;
+
 Shell App::shell_;
 
 DigitalOutArduino App::left_motor_enable_digital_out_(Hw::kLeftMotorEnableGpioPin);
@@ -165,14 +167,14 @@ void App::loop() {
   shell_.process_input();
 
   // Compute PID output at the configured rate.
-  if ((millis() - last_pid_computation_) > Constants::kPidPeriod) {
-    last_pid_computation_ = millis();
+  if ((clock_.millis() - last_pid_computation_) > Constants::kPidPeriod) {
+    last_pid_computation_ = clock_.millis();
     adjust_motors_speed();
   }
 
   // Stop the motors if auto-stop interval has been reached.
-  if ((millis() - last_set_motors_speed_cmd_) > Constants::kAutoStopWindow) {
-    last_set_motors_speed_cmd_ = millis();
+  if ((clock_.millis() - last_set_motors_speed_cmd_) > Constants::kAutoStopWindow) {
+    last_set_motors_speed_cmd_ = clock_.millis();
     stop_motors();
   }
 
@@ -245,7 +247,7 @@ void App::cmd_set_motors_speed_cb(int argc, char** argv) {
   const int right_motor_speed = atoi(argv[2]);
 
   // Reset the auto stop timer.
-  last_set_motors_speed_cmd_ = millis();
+  last_set_motors_speed_cmd_ = clock_.millis();
   if (left_motor_speed == 0 && right_motor_speed == 0) {
     left_motor_.set_speed(0);
     right_motor_.set_speed(0);
@@ -280,7 +282,7 @@ void App::cmd_set_motors_pwm_cb(int argc, char** argv) {
   right_pid_controller_.disable();
 
   // Reset the auto stop timer.
-  last_set_motors_speed_cmd_ = millis();
+  last_set_motors_speed_cmd_ = clock_.millis();
 
   left_motor_.set_speed(left_motor_pwm);
   right_motor_.set_speed(right_motor_pwm);

--- a/andino_firmware/src/bsp/clock_arduino.cpp
+++ b/andino_firmware/src/bsp/clock_arduino.cpp
@@ -1,0 +1,40 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2026, Ekumen Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "andino/bsp/clock_arduino.h"
+
+#include <Arduino.h>
+
+namespace andino {
+
+unsigned long ClockArduino::millis() const { return ::millis(); }
+
+void ClockArduino::delay(unsigned long ms) const { ::delay(ms); }
+
+}  // namespace andino


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR adds a Clock hardware abstraction interface and its corresponding Arduino implementation (ClockArduino). Previously, time-tracking logic inside the main application (app.cpp) called the Arduino global millis() function directly. This tight coupling made time-dependent behaviors (such as PID loop intervals and safety timeouts) completely untestable on desktop environments.

With this change, timing-related operations are funneled through the abstract Clock interface, laying the foundation for deterministic time simulation (using a MockClock) in unit testing on native desktop hosts.

## Test it

Build the image (if not already built):
```bash
docker compose -f docker/compose.yaml build
```

Run unit tests (all 27 tests should pass):
```bash
docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
```

Compile the firmware to verify no build regressions:
```bash
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.