### PR TITLE
[andino_firmware] Support context pointer as first argument in command callbacks

### DIFF
--- a/andino_firmware/include/andino/app/app.h
+++ b/andino_firmware/include/andino/app/app.h
@@ -63,34 +63,34 @@ class App {
   static void stop_motors();
 
   /// Callback method for an unknown command (default).
-  static void cmd_unknown_cb(int argc, char** argv);
+  static void cmd_unknown_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kReadAnalogGpio` command.
-  static void cmd_read_analog_gpio_cb(int argc, char** argv);
+  static void cmd_read_analog_gpio_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kReadDigitalGpio` command.
-  static void cmd_read_digital_gpio_cb(int argc, char** argv);
+  static void cmd_read_digital_gpio_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kReadEncoders` command.
-  static void cmd_read_encoders_cb(int argc, char** argv);
+  static void cmd_read_encoders_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kResetEncoders` command.
-  static void cmd_reset_encoders_cb(int argc, char** argv);
+  static void cmd_reset_encoders_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kSetMotorsSpeed` command.
-  static void cmd_set_motors_speed_cb(int argc, char** argv);
+  static void cmd_set_motors_speed_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kSetMotorsPwm` command.
-  static void cmd_set_motors_pwm_cb(int argc, char** argv);
+  static void cmd_set_motors_pwm_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kSetPidsTuningGains` command.
-  static void cmd_set_pid_tuning_gains_cb(int argc, char** argv);
+  static void cmd_set_pid_tuning_gains_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kGetIsImuConnected` command.
-  static void cmd_get_is_imu_connected_cb(int argc, char** argv);
+  static void cmd_get_is_imu_connected_cb(void* context, int argc, char** argv);
 
   /// Callback method for the `Commands::kReadEncodersAndImu` command.
-  static void cmd_read_encoders_and_imu_cb(int argc, char** argv);
+  static void cmd_read_encoders_and_imu_cb(void* context, int argc, char** argv);
 
   /// Serial stream.
   static SerialStreamArduino serial_stream_;

--- a/andino_firmware/include/andino/app/shell.h
+++ b/andino_firmware/include/andino/app/shell.h
@@ -39,7 +39,7 @@ namespace andino {
 class Shell {
  public:
   /// @brief Command callback type.
-  typedef void (*CommandCallback)(int argc, char** argv);
+  typedef void (*CommandCallback)(void* context, int argc, char** argv);
 
   /// @brief Sets the serial stream to use.
   ///
@@ -55,7 +55,8 @@ class Shell {
   ///
   /// @param name Command name.
   /// @param callback Callback function.
-  void register_command(const char* name, CommandCallback callback);
+  /// @param context Context pointer to pass to the callback.
+  void register_command(const char* name, CommandCallback callback, void* context = nullptr);
 
   /// @brief Processes the available input at the command prompt (if any). Meant to be called
   /// continously.
@@ -71,6 +72,8 @@ class Shell {
     char name[kCommandNameLengthMax];
     /// Callback function.
     CommandCallback callback;
+    /// Context pointer.
+    void* context;
   };
 
   /// Maximum number of commands that can be registered.

--- a/andino_firmware/src/app/app.cpp
+++ b/andino_firmware/src/app/app.cpp
@@ -204,9 +204,9 @@ void App::stop_motors() {
   right_pid_controller_.disable();
 }
 
-void App::cmd_unknown_cb(int, char**) { Serial.println("Unknown command."); }
+void App::cmd_unknown_cb(void*, int, char**) { Serial.println("Unknown command."); }
 
-void App::cmd_read_analog_gpio_cb(int argc, char** argv) {
+void App::cmd_read_analog_gpio_cb(void*, int argc, char** argv) {
   if (argc < 2) {
     return;
   }
@@ -215,7 +215,7 @@ void App::cmd_read_analog_gpio_cb(int argc, char** argv) {
   Serial.println(analogRead(pin));
 }
 
-void App::cmd_read_digital_gpio_cb(int argc, char** argv) {
+void App::cmd_read_digital_gpio_cb(void*, int argc, char** argv) {
   if (argc < 2) {
     return;
   }
@@ -224,13 +224,13 @@ void App::cmd_read_digital_gpio_cb(int argc, char** argv) {
   Serial.println(digitalRead(pin));
 }
 
-void App::cmd_read_encoders_cb(int, char**) {
+void App::cmd_read_encoders_cb(void*, int, char**) {
   Serial.print(left_encoder_.read());
   Serial.print(" ");
   Serial.println(right_encoder_.read());
 }
 
-void App::cmd_reset_encoders_cb(int, char**) {
+void App::cmd_reset_encoders_cb(void*, int, char**) {
   left_encoder_.reset();
   right_encoder_.reset();
   left_pid_controller_.reset(left_encoder_.read());
@@ -238,7 +238,7 @@ void App::cmd_reset_encoders_cb(int, char**) {
   Serial.println("OK");
 }
 
-void App::cmd_set_motors_speed_cb(int argc, char** argv) {
+void App::cmd_set_motors_speed_cb(void*, int argc, char** argv) {
   if (argc < 3) {
     return;
   }
@@ -267,7 +267,7 @@ void App::cmd_set_motors_speed_cb(int argc, char** argv) {
   Serial.println("OK");
 }
 
-void App::cmd_set_motors_pwm_cb(int argc, char** argv) {
+void App::cmd_set_motors_pwm_cb(void*, int argc, char** argv) {
   if (argc < 3) {
     return;
   }
@@ -289,7 +289,7 @@ void App::cmd_set_motors_pwm_cb(int argc, char** argv) {
   Serial.println("OK");
 }
 
-void App::cmd_set_pid_tuning_gains_cb(int argc, char** argv) {
+void App::cmd_set_pid_tuning_gains_cb(void*, int argc, char** argv) {
   // TODO(jballoffet): Refactor to expect command multiple arguments.
   if (argc < 2) {
     return;
@@ -321,9 +321,9 @@ void App::cmd_set_pid_tuning_gains_cb(int argc, char** argv) {
   Serial.println("OK");
 }
 
-void App::cmd_get_is_imu_connected_cb(int, char**) { Serial.println(is_imu_connected); }
+void App::cmd_get_is_imu_connected_cb(void*, int, char**) { Serial.println(is_imu_connected); }
 
-void App::cmd_read_encoders_and_imu_cb(int, char**) {
+void App::cmd_read_encoders_and_imu_cb(void*, int, char**) {
   Serial.print(left_encoder_.read());
   Serial.print(" ");
   Serial.print(right_encoder_.read());

--- a/andino_firmware/src/app/shell.cpp
+++ b/andino_firmware/src/app/shell.cpp
@@ -37,7 +37,7 @@ void Shell::set_serial_stream(const SerialStream* serial_stream) { serial_stream
 
 void Shell::set_default_callback(CommandCallback callback) { default_callback_ = callback; }
 
-void Shell::register_command(const char* name, CommandCallback callback) {
+void Shell::register_command(const char* name, CommandCallback callback, void* context) {
   if (commands_count_ >= kCommandsMax) {
     return;
   }
@@ -45,6 +45,7 @@ void Shell::register_command(const char* name, CommandCallback callback) {
   Command command;
   strcpy(command.name, name);
   command.callback = callback;
+  command.context = context;
   commands_[commands_count_++] = command;
 }
 
@@ -91,14 +92,14 @@ void Shell::parse_message() {
 void Shell::execute_callback(int argc, char** argv) {
   for (size_t i = 0; i < commands_count_; i++) {
     if (!strcmp(argv[0], commands_[i].name)) {
-      commands_[i].callback(argc, argv);
+      commands_[i].callback(commands_[i].context, argc, argv);
       return;
     }
   }
 
   // Unknown command received, executing default callback.
   if (default_callback_ != nullptr) {
-    default_callback_(argc, argv);
+    default_callback_(nullptr, argc, argv);
   }
 }
 

--- a/andino_firmware/test/app/test_shell/shell_test.cpp
+++ b/andino_firmware/test/app/test_shell/shell_test.cpp
@@ -77,22 +77,22 @@ class ShellTest : public testing::Test {
     shell.register_command(kCommand3, cmd_3_cb);
   }
 
-  static void cmd_unknown_cb(int argc, char** argv) {
+  static void cmd_unknown_cb(void*, int argc, char** argv) {
     called_callback_ = 0;
     save_arguments(argc, argv);
   }
 
-  static void cmd_1_cb(int argc, char** argv) {
+  static void cmd_1_cb(void*, int argc, char** argv) {
     called_callback_ = 1;
     save_arguments(argc, argv);
   }
 
-  static void cmd_2_cb(int argc, char** argv) {
+  static void cmd_2_cb(void*, int argc, char** argv) {
     called_callback_ = 2;
     save_arguments(argc, argv);
   }
 
-  static void cmd_3_cb(int argc, char** argv) {
+  static void cmd_3_cb(void*, int argc, char** argv) {
     called_callback_ = 3;
     save_arguments(argc, argv);
   }


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR refactors the Shell class to support standard C-style void* context pointers inside command callbacks, by restructuring Shell to receive and store a context pointer along with the callback function pointer. This will allow making the App class instantiable on a subsequent PR.

## Test it

Build the image (if not already built):
```bash
docker compose -f docker/compose.yaml build
```

Run unit tests (all 27 tests should pass):
```bash
docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
```

Compile the firmware to verify no build regressions:
```bash
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.