### PR TITLE
[andino_firmware] Convert App class to instantiable object with Dependency Injection

### DIFF
--- a/andino_firmware/include/andino/app/app.h
+++ b/andino_firmware/include/andino/app/app.h
@@ -31,37 +31,70 @@
 
 #include <Adafruit_BNO055.h>
 
-#include "andino/bsp/digital_out_arduino.h"
-#include "andino/drivers/encoder.h"
-#include "andino/bsp/interrupt_in_arduino.h"
+#include "andino/hal/serial_stream.h"
+#include "andino/hal/clock.h"
+#include "andino/hal/digital_out.h"
+#include "andino/hal/pwm_out.h"
+#include "andino/hal/interrupt_in.h"
 #include "andino/drivers/motor.h"
+#include "andino/drivers/encoder.h"
+#include "andino/app/constants.h"
 #include "andino/app/pid.h"
-#include "andino/bsp/pwm_out_arduino.h"
-#include "andino/bsp/serial_stream_arduino.h"
-#include "andino/bsp/clock_arduino.h"
 #include "andino/app/shell.h"
 
 namespace andino {
 
-/// @brief This class wraps the MCU main application.
+/// @brief Controller class encapsulating all Andino coordination logic.
 class App {
  public:
-  /// This class only contains static members.
-  App() = delete;
+  /**
+   * @brief Constructs a new App instance.
+   *
+   * @param clock The clock service.
+   * @param serial_stream The serial communication stream.
+   * @param left_motor_enable The left motor enable digital output.
+   * @param left_motor_forward The left motor forward PWM output.
+   * @param left_motor_backward The left motor backward PWM output.
+   * @param right_motor_enable The right motor enable digital output.
+   * @param right_motor_forward The right motor forward PWM output.
+   * @param right_motor_backward The right motor backward PWM output.
+   * @param left_encoder_a The left encoder channel A interrupt input.
+   * @param left_encoder_b The left encoder channel B interrupt input.
+   * @param right_encoder_a The right encoder channel A interrupt input.
+   * @param right_encoder_b The right encoder channel B interrupt input.
+   * @param bno055_imu The Adafruit BNO055 IMU sensor.
+   */
+  App(const Clock& clock, SerialStream& serial_stream,
+      DigitalOut& left_motor_enable, PwmOut& left_motor_forward, PwmOut& left_motor_backward,
+      DigitalOut& right_motor_enable, PwmOut& right_motor_forward, PwmOut& right_motor_backward,
+      InterruptIn& left_encoder_a, InterruptIn& left_encoder_b,
+      InterruptIn& right_encoder_a, InterruptIn& right_encoder_b,
+      Adafruit_BNO055& bno055_imu)
+      : clock_(clock),
+        serial_stream_(serial_stream),
+        left_motor_(&left_motor_enable, &left_motor_forward, &left_motor_backward),
+        right_motor_(&right_motor_enable, &right_motor_forward, &right_motor_backward),
+        left_encoder_(&left_encoder_a, &left_encoder_b),
+        right_encoder_(&right_encoder_a, &right_encoder_b),
+        bno055_imu_(bno055_imu),
+        left_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
+                              Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax),
+        right_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
+                               Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax) {}
+
+  // Delete copy and move operations to enforce unique reference ownership.
+  App(const App&) = delete;
+  App& operator=(const App&) = delete;
+  App(App&&) = delete;
+  App& operator=(App&&) = delete;
 
   /// @brief Configures and sets the application up. Meant to be called once at startup.
-  static void setup();
+  void setup();
 
-  /// @brief Application main run loop. Meant to be called continously.
-  static void loop();
+  /// @brief Application main run loop. Meant to be called continuously.
+  void loop();
 
  private:
-  /// Computes the PID output and updates the motors speed accordingly.
-  static void adjust_motors_speed();
-
-  /// Stops the motors and disables the PID.
-  static void stop_motors();
-
   /// Callback method for an unknown command (default).
   static void cmd_unknown_cb(void* context, int argc, char** argv);
 
@@ -92,52 +125,45 @@ class App {
   /// Callback method for the `Commands::kReadEncodersAndImu` command.
   static void cmd_read_encoders_and_imu_cb(void* context, int argc, char** argv);
 
-  /// Serial stream.
-  static SerialStreamArduino serial_stream_;
+  /// Computes the PID output and updates the motors speed accordingly.
+  void adjust_motors_speed();
 
-  /// System clock.
-  static ClockArduino clock_;
+  /// Stops the motors and disables the PID.
+  void stop_motors();
 
-  /// Application command shell.
-  static Shell shell_;
+  const Clock& clock_;
+
+  SerialStream& serial_stream_;
 
   /// Left wheel motor.
-  static DigitalOutArduino left_motor_enable_digital_out_;
-  static PwmOutArduino left_motor_forward_pwm_out_;
-  static PwmOutArduino left_motor_backward_pwm_out_;
-  static Motor left_motor_;
+  Motor left_motor_;
 
   /// Right wheel motor.
-  static DigitalOutArduino right_motor_enable_digital_out_;
-  static PwmOutArduino right_motor_forward_pwm_out_;
-  static PwmOutArduino right_motor_backward_pwm_out_;
-  static Motor right_motor_;
+  Motor right_motor_;
 
   /// Left wheel encoder.
-  static InterruptInArduino left_encoder_channel_a_interrupt_in_;
-  static InterruptInArduino left_encoder_channel_b_interrupt_in_;
-  static Encoder left_encoder_;
+  Encoder left_encoder_;
 
   /// Right wheel encoder.
-  static InterruptInArduino right_encoder_channel_a_interrupt_in_;
-  static InterruptInArduino right_encoder_channel_b_interrupt_in_;
-  static Encoder right_encoder_;
+  Encoder right_encoder_;
+
+  Adafruit_BNO055& bno055_imu_;
 
   /// PID controllers (one per wheel).
-  static Pid left_pid_controller_;
-  static Pid right_pid_controller_;
+  Pid left_pid_controller_;
+  Pid right_pid_controller_;
 
-  /// Adafruit BNO055 IMU sensor.
-  static Adafruit_BNO055 bno055_imu_;
+  /// Application command shell.
+  Shell shell_;
 
   /// Tracks the last time the PID computation was made.
-  static unsigned long last_pid_computation_;
+  unsigned long last_pid_computation_{0};
 
   /// Tracks the last time a `Commands::kSetMotorsSpeed` command was received.
-  static unsigned long last_set_motors_speed_cmd_;
+  unsigned long last_set_motors_speed_cmd_{0};
 
   /// Tracks whether there is an IMU sensor connected.
-  static bool is_imu_connected;
+  bool is_imu_connected{false};
 };
 
 }  // namespace andino

--- a/andino_firmware/src/app/app.cpp
+++ b/andino_firmware/src/app/app.cpp
@@ -72,58 +72,8 @@
 
 #include "andino/app/commands.h"
 #include "andino/app/constants.h"
-#include "andino/bsp/digital_out_arduino.h"
-#include "andino/drivers/encoder.h"
-#include "andino/app/hw.h"
-#include "andino/bsp/interrupt_in_arduino.h"
-#include "andino/drivers/motor.h"
-#include "andino/app/pid.h"
-#include "andino/bsp/pwm_out_arduino.h"
-#include "andino/bsp/serial_stream_arduino.h"
-#include "andino/app/shell.h"
 
 namespace andino {
-
-SerialStreamArduino App::serial_stream_;
-
-ClockArduino App::clock_;
-
-Shell App::shell_;
-
-DigitalOutArduino App::left_motor_enable_digital_out_(Hw::kLeftMotorEnableGpioPin);
-PwmOutArduino App::left_motor_forward_pwm_out_(Hw::kLeftMotorForwardGpioPin);
-PwmOutArduino App::left_motor_backward_pwm_out_(Hw::kLeftMotorBackwardGpioPin);
-Motor App::left_motor_(&left_motor_enable_digital_out_, &left_motor_forward_pwm_out_,
-                       &left_motor_backward_pwm_out_);
-
-DigitalOutArduino App::right_motor_enable_digital_out_(Hw::kRightMotorEnableGpioPin);
-PwmOutArduino App::right_motor_forward_pwm_out_(Hw::kRightMotorForwardGpioPin);
-PwmOutArduino App::right_motor_backward_pwm_out_(Hw::kRightMotorBackwardGpioPin);
-Motor App::right_motor_(&right_motor_enable_digital_out_, &right_motor_forward_pwm_out_,
-                        &right_motor_backward_pwm_out_);
-
-InterruptInArduino App::left_encoder_channel_a_interrupt_in_(Hw::kLeftEncoderChannelAGpioPin);
-InterruptInArduino App::left_encoder_channel_b_interrupt_in_(Hw::kLeftEncoderChannelBGpioPin);
-Encoder App::left_encoder_(&left_encoder_channel_a_interrupt_in_,
-                           &left_encoder_channel_b_interrupt_in_);
-
-InterruptInArduino App::right_encoder_channel_a_interrupt_in_(Hw::kRightEncoderChannelAGpioPin);
-InterruptInArduino App::right_encoder_channel_b_interrupt_in_(Hw::kRightEncoderChannelBGpioPin);
-Encoder App::right_encoder_(&right_encoder_channel_a_interrupt_in_,
-                            &right_encoder_channel_b_interrupt_in_);
-
-Pid App::left_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
-                              Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax);
-Pid App::right_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
-                               Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax);
-
-unsigned long App::last_pid_computation_{0};
-
-unsigned long App::last_set_motors_speed_cmd_{0};
-
-bool App::is_imu_connected{false};
-
-Adafruit_BNO055 App::bno055_imu_{/*sensorID=*/55, BNO055_ADDRESS_A, &Wire};
 
 void App::setup() {
   // Required by Arduino libraries to work.
@@ -145,15 +95,15 @@ void App::setup() {
   // Initialize command shell.
   shell_.set_serial_stream(&serial_stream_);
   shell_.set_default_callback(cmd_unknown_cb);
-  shell_.register_command(Commands::kReadAnalogGpio, cmd_read_analog_gpio_cb);
-  shell_.register_command(Commands::kReadDigitalGpio, cmd_read_digital_gpio_cb);
-  shell_.register_command(Commands::kReadEncoders, cmd_read_encoders_cb);
-  shell_.register_command(Commands::kResetEncoders, cmd_reset_encoders_cb);
-  shell_.register_command(Commands::kSetMotorsSpeed, cmd_set_motors_speed_cb);
-  shell_.register_command(Commands::kSetMotorsPwm, cmd_set_motors_pwm_cb);
-  shell_.register_command(Commands::kSetPidsTuningGains, cmd_set_pid_tuning_gains_cb);
-  shell_.register_command(Commands::kGetIsImuConnected, cmd_get_is_imu_connected_cb);
-  shell_.register_command(Commands::kReadEncodersAndImu, cmd_read_encoders_and_imu_cb);
+  shell_.register_command(Commands::kReadAnalogGpio, cmd_read_analog_gpio_cb, this);
+  shell_.register_command(Commands::kReadDigitalGpio, cmd_read_digital_gpio_cb, this);
+  shell_.register_command(Commands::kReadEncoders, cmd_read_encoders_cb, this);
+  shell_.register_command(Commands::kResetEncoders, cmd_reset_encoders_cb, this);
+  shell_.register_command(Commands::kSetMotorsSpeed, cmd_set_motors_speed_cb, this);
+  shell_.register_command(Commands::kSetMotorsPwm, cmd_set_motors_pwm_cb, this);
+  shell_.register_command(Commands::kSetPidsTuningGains, cmd_set_pid_tuning_gains_cb, this);
+  shell_.register_command(Commands::kGetIsImuConnected, cmd_get_is_imu_connected_cb, this);
+  shell_.register_command(Commands::kReadEncodersAndImu, cmd_read_encoders_and_imu_cb, this);
 
   // Initialize IMU sensor.
   if (bno055_imu_.begin()) {
@@ -184,26 +134,6 @@ void App::loop() {
   }
 }
 
-void App::adjust_motors_speed() {
-  int left_motor_speed = 0;
-  int right_motor_speed = 0;
-  left_pid_controller_.compute(left_encoder_.read(), left_motor_speed);
-  right_pid_controller_.compute(right_encoder_.read(), right_motor_speed);
-  if (left_pid_controller_.enabled()) {
-    left_motor_.set_speed(left_motor_speed);
-  }
-  if (right_pid_controller_.enabled()) {
-    right_motor_.set_speed(right_motor_speed);
-  }
-}
-
-void App::stop_motors() {
-  left_motor_.set_speed(0);
-  right_motor_.set_speed(0);
-  left_pid_controller_.disable();
-  right_pid_controller_.disable();
-}
-
 void App::cmd_unknown_cb(void*, int, char**) { Serial.println("Unknown command."); }
 
 void App::cmd_read_analog_gpio_cb(void*, int argc, char** argv) {
@@ -224,77 +154,82 @@ void App::cmd_read_digital_gpio_cb(void*, int argc, char** argv) {
   Serial.println(digitalRead(pin));
 }
 
-void App::cmd_read_encoders_cb(void*, int, char**) {
-  Serial.print(left_encoder_.read());
+void App::cmd_read_encoders_cb(void* context, int, char**) {
+  App* app = static_cast<App*>(context);
+  Serial.print(app->left_encoder_.read());
   Serial.print(" ");
-  Serial.println(right_encoder_.read());
+  Serial.println(app->right_encoder_.read());
 }
 
-void App::cmd_reset_encoders_cb(void*, int, char**) {
-  left_encoder_.reset();
-  right_encoder_.reset();
-  left_pid_controller_.reset(left_encoder_.read());
-  right_pid_controller_.reset(right_encoder_.read());
+void App::cmd_reset_encoders_cb(void* context, int, char**) {
+  App* app = static_cast<App*>(context);
+  app->left_encoder_.reset();
+  app->right_encoder_.reset();
+  app->left_pid_controller_.reset(app->left_encoder_.read());
+  app->right_pid_controller_.reset(app->right_encoder_.read());
   Serial.println("OK");
 }
 
-void App::cmd_set_motors_speed_cb(void*, int argc, char** argv) {
+void App::cmd_set_motors_speed_cb(void* context, int argc, char** argv) {
   if (argc < 3) {
     return;
   }
 
+  App* app = static_cast<App*>(context);
   const int left_motor_speed = atoi(argv[1]);
   const int right_motor_speed = atoi(argv[2]);
 
   // Reset the auto stop timer.
-  last_set_motors_speed_cmd_ = clock_.millis();
+  app->last_set_motors_speed_cmd_ = app->clock_.millis();
   if (left_motor_speed == 0 && right_motor_speed == 0) {
-    left_motor_.set_speed(0);
-    right_motor_.set_speed(0);
-    left_pid_controller_.reset(left_encoder_.read());
-    right_pid_controller_.reset(right_encoder_.read());
-    left_pid_controller_.disable();
-    right_pid_controller_.disable();
+    app->left_motor_.set_speed(0);
+    app->right_motor_.set_speed(0);
+    app->left_pid_controller_.reset(app->left_encoder_.read());
+    app->right_pid_controller_.reset(app->right_encoder_.read());
+    app->left_pid_controller_.disable();
+    app->right_pid_controller_.disable();
   } else {
-    left_pid_controller_.enable();
-    right_pid_controller_.enable();
+    app->left_pid_controller_.enable();
+    app->right_pid_controller_.enable();
   }
 
   // The target speeds are in ticks per second, so we need to convert them to ticks per
   // Constants::kPidRate.
-  left_pid_controller_.set_setpoint(left_motor_speed / Constants::kPidRate);
-  right_pid_controller_.set_setpoint(right_motor_speed / Constants::kPidRate);
+  app->left_pid_controller_.set_setpoint(left_motor_speed / Constants::kPidRate);
+  app->right_pid_controller_.set_setpoint(right_motor_speed / Constants::kPidRate);
   Serial.println("OK");
 }
 
-void App::cmd_set_motors_pwm_cb(void*, int argc, char** argv) {
+void App::cmd_set_motors_pwm_cb(void* context, int argc, char** argv) {
   if (argc < 3) {
     return;
   }
 
+  App* app = static_cast<App*>(context);
   const int left_motor_pwm = atoi(argv[1]);
   const int right_motor_pwm = atoi(argv[2]);
 
-  left_pid_controller_.reset(left_encoder_.read());
-  right_pid_controller_.reset(right_encoder_.read());
+  app->left_pid_controller_.reset(app->left_encoder_.read());
+  app->right_pid_controller_.reset(app->right_encoder_.read());
   // Sneaky way to temporarily disable the PID.
-  left_pid_controller_.disable();
-  right_pid_controller_.disable();
+  app->left_pid_controller_.disable();
+  app->right_pid_controller_.disable();
 
   // Reset the auto stop timer.
-  last_set_motors_speed_cmd_ = clock_.millis();
+  app->last_set_motors_speed_cmd_ = app->clock_.millis();
 
-  left_motor_.set_speed(left_motor_pwm);
-  right_motor_.set_speed(right_motor_pwm);
+  app->left_motor_.set_speed(left_motor_pwm);
+  app->right_motor_.set_speed(right_motor_pwm);
   Serial.println("OK");
 }
 
-void App::cmd_set_pid_tuning_gains_cb(void*, int argc, char** argv) {
+void App::cmd_set_pid_tuning_gains_cb(void* context, int argc, char** argv) {
   // TODO(jballoffet): Refactor to expect command multiple arguments.
   if (argc < 2) {
     return;
   }
 
+  App* app = static_cast<App*>(context);
   static constexpr int kSizePidArgs{4};
   int i = 0;
   char arg[20];
@@ -308,8 +243,8 @@ void App::cmd_set_pid_tuning_gains_cb(void*, int argc, char** argv) {
     pid_args[i] = atoi(str);
     i++;
   }
-  left_pid_controller_.set_tunings(pid_args[0], pid_args[1], pid_args[2], pid_args[3]);
-  right_pid_controller_.set_tunings(pid_args[0], pid_args[1], pid_args[2], pid_args[3]);
+  app->left_pid_controller_.set_tunings(pid_args[0], pid_args[1], pid_args[2], pid_args[3]);
+  app->right_pid_controller_.set_tunings(pid_args[0], pid_args[1], pid_args[2], pid_args[3]);
   Serial.print("PID Updated: ");
   Serial.print(pid_args[0]);
   Serial.print(" ");
@@ -321,18 +256,22 @@ void App::cmd_set_pid_tuning_gains_cb(void*, int argc, char** argv) {
   Serial.println("OK");
 }
 
-void App::cmd_get_is_imu_connected_cb(void*, int, char**) { Serial.println(is_imu_connected); }
+void App::cmd_get_is_imu_connected_cb(void* context, int, char**) {
+  App* app = static_cast<App*>(context);
+  Serial.println(app->is_imu_connected);
+}
 
-void App::cmd_read_encoders_and_imu_cb(void*, int, char**) {
-  Serial.print(left_encoder_.read());
+void App::cmd_read_encoders_and_imu_cb(void* context, int, char**) {
+  App* app = static_cast<App*>(context);
+  Serial.print(app->left_encoder_.read());
   Serial.print(" ");
-  Serial.print(right_encoder_.read());
+  Serial.print(app->right_encoder_.read());
   Serial.print(" ");
 
   // Retrieve absolute orientation (quaternion). See
   // https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor/overview for further
   // information.
-  imu::Quaternion orientation = bno055_imu_.getQuat();
+  imu::Quaternion orientation = app->bno055_imu_.getQuat();
   Serial.print(orientation.x(), 4);
   Serial.print(" ");
   Serial.print(orientation.y(), 4);
@@ -345,7 +284,7 @@ void App::cmd_read_encoders_and_imu_cb(void*, int, char**) {
   // Retrieve angular velocity (rad/s). See
   // https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor/overview for further
   // information.
-  imu::Vector<3> angular_velocity = bno055_imu_.getVector(Adafruit_BNO055::VECTOR_GYROSCOPE);
+  imu::Vector<3> angular_velocity = app->bno055_imu_.getVector(Adafruit_BNO055::VECTOR_GYROSCOPE);
   Serial.print(angular_velocity.x());
   Serial.print(" ");
   Serial.print(angular_velocity.y());
@@ -356,12 +295,32 @@ void App::cmd_read_encoders_and_imu_cb(void*, int, char**) {
   // Retrieve linear acceleration (m/s^2). See
   // https://learn.adafruit.com/adafruit-bno055-absolute-orientation-sensor/overview for further
   // information.
-  imu::Vector<3> linear_acceleration = bno055_imu_.getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
+  imu::Vector<3> linear_acceleration = app->bno055_imu_.getVector(Adafruit_BNO055::VECTOR_LINEARACCEL);
   Serial.print(linear_acceleration.x());
   Serial.print(" ");
   Serial.print(linear_acceleration.y());
   Serial.print(" ");
   Serial.print(linear_acceleration.z());
+}
+
+void App::adjust_motors_speed() {
+  int left_motor_speed = 0;
+  int right_motor_speed = 0;
+  left_pid_controller_.compute(left_encoder_.read(), left_motor_speed);
+  right_pid_controller_.compute(right_encoder_.read(), right_motor_speed);
+  if (left_pid_controller_.enabled()) {
+    left_motor_.set_speed(left_motor_speed);
+  }
+  if (right_pid_controller_.enabled()) {
+    right_motor_.set_speed(right_motor_speed);
+  }
+}
+
+void App::stop_motors() {
+  left_motor_.set_speed(0);
+  right_motor_.set_speed(0);
+  left_pid_controller_.disable();
+  right_pid_controller_.disable();
 }
 
 }  // namespace andino

--- a/andino_firmware/src/main.cpp
+++ b/andino_firmware/src/main.cpp
@@ -29,16 +29,49 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "andino/app/app.h"
 
+#include <Adafruit_BNO055.h>
+#include <Wire.h>
+
+#include "andino/app/hw.h"
+#include "andino/bsp/clock_arduino.h"
+#include "andino/bsp/digital_out_arduino.h"
+#include "andino/bsp/interrupt_in_arduino.h"
+#include "andino/bsp/pwm_out_arduino.h"
+#include "andino/bsp/serial_stream_arduino.h"
+
+// BSP implementations.
+static andino::ClockArduino sys_clock;
+static andino::SerialStreamArduino serial_stream;
+static andino::DigitalOutArduino left_motor_enable(andino::Hw::kLeftMotorEnableGpioPin);
+static andino::PwmOutArduino left_motor_forward(andino::Hw::kLeftMotorForwardGpioPin);
+static andino::PwmOutArduino left_motor_backward(andino::Hw::kLeftMotorBackwardGpioPin);
+static andino::DigitalOutArduino right_motor_enable(andino::Hw::kRightMotorEnableGpioPin);
+static andino::PwmOutArduino right_motor_forward(andino::Hw::kRightMotorForwardGpioPin);
+static andino::PwmOutArduino right_motor_backward(andino::Hw::kRightMotorBackwardGpioPin);
+static andino::InterruptInArduino left_encoder_a(andino::Hw::kLeftEncoderChannelAGpioPin);
+static andino::InterruptInArduino left_encoder_b(andino::Hw::kLeftEncoderChannelBGpioPin);
+static andino::InterruptInArduino right_encoder_a(andino::Hw::kRightEncoderChannelAGpioPin);
+static andino::InterruptInArduino right_encoder_b(andino::Hw::kRightEncoderChannelBGpioPin);
+static Adafruit_BNO055 bno055_imu(55, BNO055_ADDRESS_A, &Wire);
+
+// Main application.
+static andino::App app(sys_clock, serial_stream,
+                       left_motor_enable, left_motor_forward, left_motor_backward,
+                       right_motor_enable, right_motor_forward, right_motor_backward,
+                       left_encoder_a, left_encoder_b,
+                       right_encoder_a, right_encoder_b,
+                       bno055_imu);
+
 /// @brief Application entry point.
 ///
 /// @return Execution final status (never reached).
 int main(void) {
   // Application configuration.
-  andino::App::setup();
+  app.setup();
 
   // Application main run loop.
   while (1) {
-    andino::App::loop();
+    app.loop();
   }
 
   return 0;


### PR DESCRIPTION
# 🎉 New feature

## Summary

Following the refactoring of the Shell command registry to support void* context pointers, this PR converts the main application coordinator (App) into an instantiable class utilizing constructor-based Dependency Injection (DI).

Concrete BSP implementations are now composed and instanced statically in main.cpp (acting as the Composition Root) and cleanly injected into the constructed global App instance.

## Test it

Build the image (if not already built):
```bash
docker compose -f docker/compose.yaml build
```

Run unit tests (all 27 tests should pass):
```bash
docker compose -f docker/compose.yaml run --rm dev pio test -e desktop
```

Compile the firmware to verify no build regressions:
```bash
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.