### PR TITLE
[andino_firmware] Fix MCU CI to run on main and enforce linting

### DIFF
--- a/.github/workflows/mcu-ci.yml
+++ b/.github/workflows/mcu-ci.yml
@@ -32,13 +32,26 @@ name: MCU CI
 on:
   push:
     branches:
-      - humble
+      - main
   pull_request:
     branches:
-      - humble
+      - main
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Run pre-commit checks (formatting and style linting)
+        run: |
+          pip install pre-commit
+          pre-commit run --show-diff-on-failure --files $(git ls-files andino_firmware)
+
   build_and_test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR retargets mcu-ci.yml triggers from the deprecated humble branch to main, adds a lint job that runs the existing pre-commit hooks (clang-format, cpplint) on every push/PR.

## Test it
CI passed.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
