### PR TITLE
[andino_firmware] Scope compiler warning flags to project source and add stricter checks

### DIFF
--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -15,9 +15,15 @@ default_envs = uno, nanoatmega328
 [base_build]
 build_flags =
   -I include
+build_src_flags =
   -Wall -Wextra
   -Wshadow
   -Wdouble-promotion
+  -Woverloaded-virtual
+  -Wcast-qual
+  -Wuseless-cast
+  -Wnull-dereference
+  -Werror
 check_tool = cppcheck
 check_skip_packages = yes
 check_flags =


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR splits build_flags into build_flags (just -I include) and build_src_flags, so warning enforcement only applies to our own src/ code and not to frameworks/libraries we don't control. It also adds -Werror so warnings fail the build, scoped to build_src_flags, and adds -Woverloaded-virtual, -Wcast-qual, -Wuseless-cast, and -Wnull-dereference for additional static safety.

## Test it

```
docker compose -f docker/compose.yaml run --rm dev pio run -e uno
Container andino-firmware-dev-run-e2b330fe2cbd Creating 
Container andino-firmware-dev-run-e2b330fe2cbd Created 
Processing uno (board: uno; platform: atmelavr; framework: arduino)
-----------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/atmelavr/uno.html
PLATFORM: Atmel AVR (5.3.0) > Arduino Uno
HARDWARE: ATMEGA328P 16MHz, 2KB RAM, 31.50KB Flash
DEBUG: Current (avr-stub) External (avr-stub, simavr)
PACKAGES: 
 - framework-arduino-avr @ 5.4.0 
 - toolchain-atmelavr @ 1.70300.191015 (7.3.0)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 8 compatible libraries
Scanning dependencies...
Dependency Graph
|-- Wire @ 1.0
|-- SPI @ 1.0
|-- Adafruit BNO055 @ 1.6.4
|-- Adafruit BusIO @ 1.17.4
|-- Adafruit Unified Sensor @ 1.1.15
Building in release mode
Checking size .pio/build/uno/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=====     ]  51.5% (used 1055 bytes from 2048 bytes)
Flash: [=====     ]  51.2% (used 16502 bytes from 32256 bytes)
========================================================= [SUCCESS] Took 0.50 seconds =========================================================

Environment    Status    Duration
-------------  --------  ------------
uno            SUCCESS   00:00:00.502
========================================================= 1 succeeded in 00:00:00.502 =========================================================
```

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
