### PR TITLE
[andino_firmware] Add static analysis to CI and fix cppcheck findings

### DIFF
--- a/.github/workflows/mcu-ci.yml
+++ b/.github/workflows/mcu-ci.yml
@@ -58,6 +58,9 @@ jobs:
       - name: Build application
         working-directory: ./andino_firmware
         run: pio run
+      - name: Run static analysis
+        working-directory: ./andino_firmware
+        run: pio check --fail-on-defect=medium
       - name: Run unit tests
         working-directory: ./andino_firmware
         run: pio test --environment=desktop

--- a/andino_firmware/include/andino/app/app.h
+++ b/andino_firmware/include/andino/app/app.h
@@ -86,7 +86,8 @@ class App {
         left_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
                              Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax),
         right_pid_controller_(Constants::kPidKp, Constants::kPidKd, Constants::kPidKi,
-                              Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax) {
+                              Constants::kPidKo, -Constants::kPwmMax, Constants::kPwmMax),
+        shell_() {
   }
 
   // Delete copy and move operations to enforce unique reference ownership.

--- a/andino_firmware/include/andino/app/app.h
+++ b/andino_firmware/include/andino/app/app.h
@@ -29,7 +29,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
 #include <Adafruit_BNO055.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 #include "andino/app/constants.h"
 #include "andino/app/pid.h"

--- a/andino_firmware/include/andino/app/constants.h
+++ b/andino_firmware/include/andino/app/constants.h
@@ -49,7 +49,7 @@ struct Constants {
   /// @brief PID computation rate [Hz].
   static constexpr int kPidRate{30};
   /// @brief PID computation period [ms].
-  static constexpr double kPidPeriod{1000 / kPidRate};
+  static constexpr long kPidPeriod{1000 / kPidRate};
   /// @brief PID default tuning proportional gain.
   static constexpr int kPidKp{30};
   /// @brief PID default tuning derivative gain.

--- a/andino_firmware/include/andino/app/hw.h
+++ b/andino_firmware/include/andino/app/hw.h
@@ -29,42 +29,44 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <stdint.h>
+
 namespace andino {
 
 /// @brief Hardware configuration.
 struct Hw {
   /// @brief Left encoder channel A pin. Connected to PD2 (digital pin 2).
-  static constexpr int kLeftEncoderChannelAGpioPin{2};
+  static constexpr uint8_t kLeftEncoderChannelAGpioPin{2};
   /// @brief Left encoder channel B pin. Connected to PD3 (digital pin 3).
-  static constexpr int kLeftEncoderChannelBGpioPin{3};
+  static constexpr uint8_t kLeftEncoderChannelBGpioPin{3};
 
   /// @brief Right encoder channel A pin. Connected to PC2 (digital pin 16, analog pin A2).
-  static constexpr int kRightEncoderChannelAGpioPin{16};
+  static constexpr uint8_t kRightEncoderChannelAGpioPin{16};
   /// @brief Right encoder channel B pin. Connected to PC3 (digital pin 17, analog pin A3).
-  static constexpr int kRightEncoderChannelBGpioPin{17};
+  static constexpr uint8_t kRightEncoderChannelBGpioPin{17};
 
   /// @brief Left motor driver backward pin. Connected to PD6 (digital pin 6).
-  static constexpr int kLeftMotorBackwardGpioPin{6};
+  static constexpr uint8_t kLeftMotorBackwardGpioPin{6};
   /// @brief Left motor driver forward pin. Connected to PB2 (digital pin 10).
-  static constexpr int kLeftMotorForwardGpioPin{10};
+  static constexpr uint8_t kLeftMotorForwardGpioPin{10};
   /// @brief Left motor driver enable pin. Connected to PB5 (digital pin 13).
   /// @note The enable input of the L298N motor driver may be directly jumped to 5V if the board has
   /// a jumper to do so.
-  static constexpr int kLeftMotorEnableGpioPin{13};
+  static constexpr uint8_t kLeftMotorEnableGpioPin{13};
 
   /// @brief Right motor driver backward pin. Connected to PD5 (digital pin 5).
-  static constexpr int kRightMotorBackwardGpioPin{5};
+  static constexpr uint8_t kRightMotorBackwardGpioPin{5};
   /// @brief Right motor driver forward pin. Connected to PB1 (digital pin 9).
-  static constexpr int kRightMotorForwardGpioPin{9};
+  static constexpr uint8_t kRightMotorForwardGpioPin{9};
   /// @brief Right motor driver enable pin. Connected to PB4 (digital pin 12).
   /// @note The enable input of the L298N motor driver may be directly jumped to 5V if the board has
   /// a jumper to do so.
-  static constexpr int kRightMotorEnableGpioPin{12};
+  static constexpr uint8_t kRightMotorEnableGpioPin{12};
 
   /// @brief IMU sensor I2C SCL pin. Connected to PC5 (digital pin 19, analog pin A5).
-  static constexpr int kImuI2cSclPin{19};
+  static constexpr uint8_t kImuI2cSclPin{19};
   /// @brief IMU sensor I2C SDA pin. Connected to PC4 (digital pin 18, analog pin A4).
-  static constexpr int kImuI2cSdaPin{18};
+  static constexpr uint8_t kImuI2cSdaPin{18};
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/app/pid.h
+++ b/andino_firmware/include/andino/app/pid.h
@@ -49,7 +49,7 @@ class Pid {
   /// @brief Resets the PID controller.
   ///
   /// @param encoder_count Current encoder value.
-  void reset(int encoder_count);
+  void reset(long encoder_count);
 
   /// @brief Returns if the PID controller is enabled or not.
   bool enabled();
@@ -64,7 +64,7 @@ class Pid {
   ///
   /// @param encoder_count Current encoder value.
   /// @param computed_output Computed output value.
-  void compute(int encoder_count, int& computed_output);
+  void compute(long encoder_count, int& computed_output);
 
   /// @brief Sets the setpoint.
   ///

--- a/andino_firmware/include/andino/app/shell.h
+++ b/andino_firmware/include/andino/app/shell.h
@@ -98,13 +98,13 @@ class Shell {
   CommandCallback default_callback_{nullptr};
 
   /// Command registry.
-  Command commands_[kCommandsMax];
+  Command commands_[kCommandsMax]{};
 
   /// Number of registered commands.
   size_t commands_count_{0};
 
   /// Command prompt message.
-  char message_buffer_[kCommandPromptLengthMax];
+  char message_buffer_[kCommandPromptLengthMax]{};
 
   /// Command prompt message index.
   int message_index_{0};

--- a/andino_firmware/include/andino/bsp/digital_out_arduino.h
+++ b/andino_firmware/include/andino/bsp/digital_out_arduino.h
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <stdint.h>
+
 #include "andino/hal/digital_out.h"
 
 namespace andino {
@@ -39,16 +41,16 @@ class DigitalOutArduino : public DigitalOut {
   /// @brief Constructs a DigitalOutArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit DigitalOutArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {
+  explicit DigitalOutArduino(const uint8_t gpio_pin) : gpio_pin_(gpio_pin) {
   }
 
   void begin() const override;
 
-  void write(int value) const override;
+  void write(uint8_t value) const override;
 
  private:
   /// GPIO pin.
-  const int gpio_pin_;
+  const uint8_t gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/bsp/interrupt_in_arduino.h
+++ b/andino_firmware/include/andino/bsp/interrupt_in_arduino.h
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <stdint.h>
+
 #include "andino/hal/interrupt_in.h"
 
 namespace andino {
@@ -39,7 +41,7 @@ class InterruptInArduino : public InterruptIn {
   /// @brief Constructs a InterruptInArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit InterruptInArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {
+  explicit InterruptInArduino(const uint8_t gpio_pin) : gpio_pin_(gpio_pin) {
   }
 
   void begin() const override;
@@ -50,7 +52,7 @@ class InterruptInArduino : public InterruptIn {
 
  private:
   /// GPIO pin.
-  const int gpio_pin_;
+  const uint8_t gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/bsp/pwm_out_arduino.h
+++ b/andino_firmware/include/andino/bsp/pwm_out_arduino.h
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <stdint.h>
+
 #include "andino/hal/pwm_out.h"
 
 namespace andino {
@@ -39,7 +41,7 @@ class PwmOutArduino : public PwmOut {
   /// @brief Constructs a PwmOutArduino using the specified GPIO pin.
   ///
   /// @param gpio_pin GPIO pin.
-  explicit PwmOutArduino(const int gpio_pin) : gpio_pin_(gpio_pin) {
+  explicit PwmOutArduino(const uint8_t gpio_pin) : gpio_pin_(gpio_pin) {
   }
 
   void begin() const override;
@@ -48,7 +50,7 @@ class PwmOutArduino : public PwmOut {
 
  private:
   /// GPIO pin.
-  const int gpio_pin_;
+  const uint8_t gpio_pin_;
 };
 
 }  // namespace andino

--- a/andino_firmware/include/andino/drivers/encoder.h
+++ b/andino_firmware/include/andino/drivers/encoder.h
@@ -127,9 +127,12 @@ class Encoder {
   static const InterruptIn::InterruptCallback kCallbacks[kInstancesMax];
 
   /// Static wrapper that redirects to the first instance callback method.
+  // cppcheck-suppress unusedPrivateFunction
+  // Referenced only through the kCallbacks function pointer table, which cppcheck can't trace.
   static void callback_0();
 
   /// Static wrapper that redirects to the second instance callback method.
+  // cppcheck-suppress unusedPrivateFunction
   static void callback_1();
 
   /// Channels interrupt callback.

--- a/andino_firmware/include/andino/hal/digital_out.h
+++ b/andino_firmware/include/andino/hal/digital_out.h
@@ -29,6 +29,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <stdint.h>
+
 namespace andino {
 
 /// @brief This class defines an interface for digital outputs.
@@ -43,7 +45,7 @@ class DigitalOut {
   /// @brief Sets the digital output value (0 or 1).
   ///
   /// @param value Digital output value.
-  virtual void write(int value) const = 0;
+  virtual void write(uint8_t value) const = 0;
 };
 
 }  // namespace andino

--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -23,6 +23,8 @@ build_src_flags =
   -Wcast-qual
   -Wuseless-cast
   -Wnull-dereference
+  -Wconversion
+  -Wsign-conversion
   -Werror
 check_tool = cppcheck
 check_skip_packages = yes

--- a/andino_firmware/platformio.ini
+++ b/andino_firmware/platformio.ini
@@ -15,9 +15,15 @@ default_envs = uno, nanoatmega328
 [base_build]
 build_flags =
   -I include
+build_src_flags =
   -Wall -Wextra
   -Wshadow
   -Wdouble-promotion
+  -Woverloaded-virtual
+  -Wcast-qual
+  -Wuseless-cast
+  -Wnull-dereference
+  -Werror
 check_tool = cppcheck
 check_skip_packages = yes
 check_flags =

--- a/andino_firmware/src/app/app.cpp
+++ b/andino_firmware/src/app/app.cpp
@@ -145,7 +145,7 @@ void App::cmd_read_analog_gpio_cb(void*, int argc, char** argv) {
     return;
   }
 
-  const int pin = atoi(argv[1]);
+  const uint8_t pin = static_cast<uint8_t>(atoi(argv[1]));
   Serial.println(analogRead(pin));
 }
 
@@ -154,7 +154,7 @@ void App::cmd_read_digital_gpio_cb(void*, int argc, char** argv) {
     return;
   }
 
-  const int pin = atoi(argv[1]);
+  const uint8_t pin = static_cast<uint8_t>(atoi(argv[1]));
   Serial.println(digitalRead(pin));
 }
 

--- a/andino_firmware/src/app/pid.cpp
+++ b/andino_firmware/src/app/pid.cpp
@@ -71,7 +71,7 @@ namespace andino {
 //  - http://brettbeauregard.com/blog/2011/04/improving-the-beginner%E2%80%99s-pid-derivative-kick/
 //  - http://brettbeauregard.com/blog/2011/04/improving-the-beginner%E2%80%99s-pid-tuning-changes/
 
-void Pid::reset(int encoder_count) {
+void Pid::reset(long encoder_count) {
   // Since we can assume that the PID is only turned on when going from stop to moving, we can init
   // everything on zero.
   setpoint_ = 0;
@@ -96,7 +96,7 @@ void Pid::disable() {
   enabled_ = false;
 }
 
-void Pid::compute(int encoder_count, int& computed_output) {
+void Pid::compute(long encoder_count, int& computed_output) {
   if (!enabled_) {
     // Reset PID once to prevent startup spikes.
     if (last_input_ != 0) {
@@ -105,7 +105,9 @@ void Pid::compute(int encoder_count, int& computed_output) {
     return;
   }
 
-  int input = encoder_count - last_encoder_count_;
+  // The tick count itself is unbounded, but the delta between two consecutive PID cycles is
+  // always small (a few dozen ticks at most), so it safely fits back into an int.
+  int input = static_cast<int>(encoder_count - last_encoder_count_);
   long error = setpoint_ - input;
 
   long output = (kp_ * error - kd_ * (input - last_input_) + integral_term_) / ko_;
@@ -117,11 +119,14 @@ void Pid::compute(int encoder_count, int& computed_output) {
   } else if (output <= output_min_) {
     output = output_min_;
   } else {
-    integral_term_ += ki_ * error;
+    // ki_ * error safely fits into an int: it is only accumulated while output (which is
+    // derived from the same magnitudes) is within the int-sized output_min_/output_max_ bounds.
+    integral_term_ += static_cast<int>(ki_ * error);
   }
 
-  // Set the computed output accordingly.
-  computed_output = output;
+  // output is clamped to output_min_/output_max_ above, both of which are int, so this narrowing
+  // is safe.
+  computed_output = static_cast<int>(output);
 
   // Store obtained values.
   last_encoder_count_ = encoder_count;

--- a/andino_firmware/src/app/shell.cpp
+++ b/andino_firmware/src/app/shell.cpp
@@ -56,7 +56,9 @@ void Shell::register_command(const char* name, CommandCallback callback, void* c
 
 void Shell::process_input() {
   while (serial_stream_->available() > 0) {
-    const char input = serial_stream_->read();
+    // read() only returns -1 when no data is available, which the available() check above rules
+    // out, so the returned byte always fits in a char.
+    const char input = static_cast<char>(serial_stream_->read());
 
     switch (input) {
       case '\r':

--- a/andino_firmware/src/app/shell.cpp
+++ b/andino_firmware/src/app/shell.cpp
@@ -90,7 +90,7 @@ void Shell::parse_message() {
   char* saveptr = nullptr;
 
   argv[argc] = strtok_r(message_buffer_, " ", &saveptr);
-  while (argv[argc] != NULL && argc < (kCommandArgMax - 1)) {
+  while (argc < (kCommandArgMax - 1) && argv[argc] != NULL) {
     argv[++argc] = strtok_r(NULL, " ", &saveptr);
   }
 

--- a/andino_firmware/src/bsp/digital_out_arduino.cpp
+++ b/andino_firmware/src/bsp/digital_out_arduino.cpp
@@ -37,7 +37,7 @@ void DigitalOutArduino::begin() const {
   pinMode(gpio_pin_, OUTPUT);
 }
 
-void DigitalOutArduino::write(int value) const {
+void DigitalOutArduino::write(uint8_t value) const {
   digitalWrite(gpio_pin_, value);
 }
 

--- a/andino_firmware/src/bsp/interrupt_in_arduino.cpp
+++ b/andino_firmware/src/bsp/interrupt_in_arduino.cpp
@@ -77,7 +77,7 @@ void InterruptInArduino::attach(InterruptCallback callback) const {
   }
 
   // Ports B, C and D values are 2, 3 and 4 correspondingly.
-  port -= 2;
+  port = static_cast<uint8_t>(port - 2);
 
   // Set corresponding bit in the appropriate Pin Change Mask register.
   *(kPortToPCMask[port]) |= bit_mask;

--- a/andino_firmware/src/drivers/encoder.cpp
+++ b/andino_firmware/src/drivers/encoder.cpp
@@ -114,9 +114,12 @@ void Encoder::reset() {
 }
 
 void Encoder::callback() {
-  // Read the current channels state into the lowest 2 bits of the encoder state.
-  state_ <<= 2;
-  state_ |= (channel_b_interrupt_in_->read() << 1) | channel_a_interrupt_in_->read();
+  // Read the current channels state into the lowest 2 bits of the encoder state. The shifted and
+  // OR'd bits are masked down to the lookup table's 4-bit range below, so the narrowing back to
+  // uint8_t after integer promotion doesn't drop any bits we care about.
+  state_ = static_cast<uint8_t>(state_ << 2);
+  state_ = static_cast<uint8_t>(state_ | (channel_b_interrupt_in_->read() << 1) |
+                                channel_a_interrupt_in_->read());
 
   // Update the encoder count accordingly.
   count_ += kTicksDelta[(state_ & 0x0F)];

--- a/andino_firmware/src/main.cpp
+++ b/andino_firmware/src/main.cpp
@@ -27,7 +27,16 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Silence warnings from this vendored, third-party header that we don't control (its templated
+// matrix/vector math implicitly narrows integer types).
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
 #include <Adafruit_BNO055.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 #include <Wire.h>
 
 #include "andino/app/app.h"

--- a/andino_firmware/test/app/test_shell/shell_test.cpp
+++ b/andino_firmware/test/app/test_shell/shell_test.cpp
@@ -129,14 +129,14 @@ TEST_F(ShellTest, ProcessInputMessageSingleCharacterCommandSingleArg) {
   const std::string input_message{"a\r"};
   const std::vector<std::string> expected_argv{"a"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -152,14 +152,14 @@ TEST_F(ShellTest, ProcessInputMessageUnknownCommand) {
   const std::string input_message{"z\r"};
   const std::vector<std::string> expected_argv{"z"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -175,14 +175,14 @@ TEST_F(ShellTest, ProcessInputMessageTwoCharacterCommandSingleArg) {
   const std::string input_message{"ab\r"};
   const std::vector<std::string> expected_argv{"ab"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -198,14 +198,14 @@ TEST_F(ShellTest, ProcessInputMessageThreeCharacterCommandSingleArg) {
   const std::string input_message{"cde\r"};
   const std::vector<std::string> expected_argv{"cde"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -221,14 +221,14 @@ TEST_F(ShellTest, ProcessInputMessageTwoArgs) {
   const std::string input_message{"a 12\r"};
   const std::vector<std::string> expected_argv{"a", "12"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -244,14 +244,14 @@ TEST_F(ShellTest, ProcessInputMessageThreeArgs) {
   const std::string input_message{"ab 12 3\r"};
   const std::vector<std::string> expected_argv{"ab", "12", "3"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));
@@ -267,14 +267,14 @@ TEST_F(ShellTest, ProcessInputMessageFourArgs) {
   const std::string input_message{"cde 12 3 456\r"};
   const std::vector<std::string> expected_argv{"cde", "12", "3", "456"};
 
-  int available_call_count = input_message.size() + 1;
+  int available_call_count = static_cast<int>(input_message.size()) + 1;
   EXPECT_CALL(serial_stream_, available()).Times(available_call_count);
   ON_CALL(serial_stream_, available())
       .WillByDefault(
           testing::Invoke([&available_call_count]() -> int { return --available_call_count; }));
 
-  int input_index = 0;
-  EXPECT_CALL(serial_stream_, read()).Times(input_message.size());
+  size_t input_index = 0;
+  EXPECT_CALL(serial_stream_, read()).Times(static_cast<int>(input_message.size()));
   ON_CALL(serial_stream_, read())
       .WillByDefault(testing::Invoke(
           [input_message, &input_index]() -> int { return input_message.at(input_index++); }));

--- a/andino_firmware/test/drivers/test_motor/motor_test.cpp
+++ b/andino_firmware/test/drivers/test_motor/motor_test.cpp
@@ -43,7 +43,7 @@ class MockDigitalOut : public andino::DigitalOut {
  public:
   MockDigitalOut() = default;
   MOCK_METHOD(void, begin, (), (const, override));
-  MOCK_METHOD(void, write, (int value), (const, override));
+  MOCK_METHOD(void, write, (uint8_t value), (const, override));
 };
 
 class MockPwmOut : public andino::PwmOut {


### PR DESCRIPTION
# 🎉 New feature

## Summary

This PR adds a pio check --fail-on-defect=medium step to the build_and_test CI job, right after pio run, so static analysis runs on every push/PR. It also fixes the findings it surfaced.

## Test it

```
docker compose -f docker/compose.yaml run --rm dev pio check --fail-on-defect=medium
Container andino-firmware-dev-run-199f9cc9643b Creating 
Container andino-firmware-dev-run-199f9cc9643b Created 
Checking uno > cppcheck (board: uno; platform: atmelavr; framework: arduino)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
.pio/libdeps/uno/Adafruit BusIO/Adafruit_I2CDevice.h:10: [low:style] Class 'Adafruit_I2CDevice' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:282: [low:style] Class 'Adafruit_BNO055' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 3 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 2 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:302: [low:style] The function 'getEvent' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:304: [low:style] The function 'getSensor' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:64: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:119: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/uno/Adafruit BusIO/Adafruit_I2CDevice.h:10: [low:style] Class 'Adafruit_I2CDevice' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:282: [low:style] Class 'Adafruit_BNO055' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 3 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 2 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:302: [low:style] The function 'getEvent' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/uno/Adafruit BNO055/Adafruit_BNO055.h:304: [low:style] The function 'getSensor' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:64: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/uno/Adafruit BNO055/utility/vector.h:119: [low:style] Local variable 'x' shadows outer function [shadowFunction]
============================================================================================================== [PASSED] Took 0.43 seconds ==============================================================================================================
Checking nanoatmega328 > cppcheck (board: nanoatmega328; platform: atmelavr; framework: arduino)
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
.pio/libdeps/nanoatmega328/Adafruit BusIO/Adafruit_I2CDevice.h:10: [low:style] Class 'Adafruit_I2CDevice' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:282: [low:style] Class 'Adafruit_BNO055' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 3 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 2 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:302: [low:style] The function 'getEvent' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:304: [low:style] The function 'getSensor' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:64: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:119: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/nanoatmega328/Adafruit BusIO/Adafruit_I2CDevice.h:10: [low:style] Class 'Adafruit_I2CDevice' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:282: [low:style] Class 'Adafruit_BNO055' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 3 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:37: [low:style] Class 'Vector < 2 >' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:302: [low:style] The function 'getEvent' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/nanoatmega328/Adafruit BNO055/Adafruit_BNO055.h:304: [low:style] The function 'getSensor' overrides a function in a base class but is not marked with a 'override' specifier. [missingOverride]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:64: [low:style] Local variable 'x' shadows outer function [shadowFunction]
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility/vector.h:119: [low:style] Local variable 'x' shadows outer function [shadowFunction]
============================================================================================================== [PASSED] Took 0.42 seconds ==============================================================================================================

Component                                            HIGH    MEDIUM    LOW
--------------------------------------------------  ------  --------  -----
.pio/libdeps/nanoatmega328/Adafruit BNO055            0        0        6
.pio/libdeps/nanoatmega328/Adafruit BNO055/utility    0        0        8
.pio/libdeps/nanoatmega328/Adafruit BusIO             0        0        2
.pio/libdeps/uno/Adafruit BNO055                      0        0        6
.pio/libdeps/uno/Adafruit BNO055/utility              0        0        8
.pio/libdeps/uno/Adafruit BusIO                       0        0        2

Total                                                 0        0       32

Environment    Tool      Status    Duration
-------------  --------  --------  ------------
uno            cppcheck  PASSED    00:00:00.434
nanoatmega328  cppcheck  PASSED    00:00:00.421
============================================================================================================= 2 succeeded in 00:00:00.855 =============================================================================================================
```

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
